### PR TITLE
Include netp in workspace; implement tcp-ipv4-port matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,8 +908,8 @@ dependencies = [
 [[package]]
 name = "netp"
 version = "0.1.0"
-source = "git+https://github.com/AOx0/netp-1#386c78639c62880001b0de9f5ed9484644bbdf43"
 dependencies = [
+ "aya-ebpf-bindings",
  "etherparse",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,8 @@
 [workspace]
-members = ["xtask", "firewall", "firewall-common", "controller", "message"]
+members = ["xtask", "firewall", "firewall-common", "controller", "message", "netp"]
 resolver = "2"
 
 [workspace.dependencies]
-netp = { git = "https://github.com/AOx0/netp-1", version = "0.1.0" }
 bstr = "1.10.0"
 async-bincode = "0.7.2"
 futures = "0.3.30"

--- a/firewall-common/Cargo.toml
+++ b/firewall-common/Cargo.toml
@@ -12,7 +12,7 @@ schema = ["user", "dep:schemars", "netp/schema"]
 [dependencies]
 aya = { version = "0.12", optional = true }
 aya-ebpf = { version = "0.1.0", optional = true }
-netp = { workspace = true }
+netp.path = "../netp"
 serde = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 

--- a/firewall-common/src/lib.rs
+++ b/firewall-common/src/lib.rs
@@ -2,6 +2,10 @@
 
 pub const MAX_RULES: u32 = 100;
 
+pub mod processor {
+    pub const IPV4_TCP: u32 = 0;
+}
+
 pub use netp;
 use netp::network::InetProtocol;
 

--- a/firewall-ebpf/Cargo.lock
+++ b/firewall-ebpf/Cargo.lock
@@ -119,7 +119,6 @@ dependencies = [
 [[package]]
 name = "netp"
 version = "0.1.0"
-source = "git+https://github.com/AOx0/netp-1#238ec02ba5b8f5f349872fe3f0d9fc512faace06"
 dependencies = [
  "aya-ebpf-bindings",
  "etherparse",

--- a/firewall-ebpf/Cargo.toml
+++ b/firewall-ebpf/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 aya-ebpf = "0.1.0"
 aya-log-ebpf = "0.1.0"
 firewall-common = { path = "../firewall-common", features = ["bpf"] }
-netp = { git = "https://github.com/AOx0/netp-1", version = "0.1.0", features = ["aya"] }
+netp = { path = "../netp", features = ["aya"] }
 
 [[bin]]
 name = "firewall"

--- a/firewall-ebpf/src/main.rs
+++ b/firewall-ebpf/src/main.rs
@@ -1,24 +1,29 @@
 #![no_std]
 #![no_main]
+#![feature(let_chains)]
 
 use core::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use aya_ebpf::{
     bindings::xdp_action,
     macros::{map, xdp},
-    maps::{Array, RingBuf},
+    maps::{Array, ProgramArray, RingBuf},
     programs::XdpContext,
 };
-use aya_log_ebpf::error;
+use aya_log_ebpf::{error, info};
 use firewall_common::{
-    Direction, FirewallAction, FirewallEvent, FirewallMatch, FirewallRule, MAX_RULES,
+    processor, Direction, FirewallAction, FirewallEvent, FirewallMatch, FirewallRule, MAX_RULES,
 };
 use netp::{
     aya::XdpErr,
     bounds,
     link::{EtherType, Ethernet},
-    network::IPv4,
+    network::{IPv4, InetProtocol},
+    transport::tcp::Tcp,
 };
+
+#[map]
+static PROCESSOR: ProgramArray = ProgramArray::with_max_entries(50, 0);
 
 #[map]
 static FIREWALL_EVENTS: RingBuf = RingBuf::with_byte_size(4096, 0);
@@ -48,9 +53,8 @@ fn try_firewall(ctx: XdpContext) -> Result<u32, u32> {
 
     if let EtherType::IPv4 = eth.ethertype() {
         bounds!(ctx, eth.size_usize() + IPv4::MIN_LEN).or_drop()?;
-        let (ip4, _rem): (IPv4<&[u8]>, &[u8]) = IPv4::new(rem).or_drop()?;
+        let (ip4, _): (IPv4<&[u8]>, &[u8]) = IPv4::new(rem).or_drop()?;
 
-        // while let Some(rule) = FIREWALL_RULES.get(i) {
         for i in 0..MAX_RULES {
             let Some(
                 rule @ FirewallRule {
@@ -84,6 +88,69 @@ fn try_firewall(ctx: XdpContext) -> Result<u32, u32> {
                 if addr.to_bits() == matching_ip {
                     return emit(ctx, rule.action, Some((i, socket_addr)));
                 }
+            }
+        }
+
+        unsafe { PROCESSOR.tail_call(&ctx, processor::IPV4_TCP).or_drop()? };
+    }
+
+    emit(ctx, FirewallAction::Accept, None)
+}
+
+#[xdp]
+pub fn ipv4_tcp(ctx: XdpContext) -> u32 {
+    match try_ipv4_tcp(ctx) {
+        Ok(c) => c,
+        Err(c) => c,
+    }
+}
+
+/// This must be called only when IPV4 + Tcp
+fn try_ipv4_tcp(ctx: XdpContext) -> Result<u32, u32> {
+    let packet = unsafe {
+        core::slice::from_raw_parts_mut(ctx.data() as *mut u8, ctx.data_end() - ctx.data())
+    };
+
+    bounds!(ctx, Ethernet::MIN_LEN + IPv4::MIN_LEN + Tcp::MIN_LEN).or_drop()?;
+    let (eth, rem) = Ethernet::new(packet).or_pass()?;
+    let (ip4, rem) = IPv4::new(rem).or_drop()?;
+
+    bounds!(ctx, eth.size_usize() + ip4.size_usize() + Tcp::MIN_LEN).or_drop()?;
+    let (tcp, _) = Tcp::new(rem).or_drop()?;
+
+    for i in 0..MAX_RULES {
+        let Some(
+            rule @ FirewallRule {
+                init: true,
+                enabled: true,
+                ..
+            },
+        ) = FIREWALL_RULES.get(i)
+        else {
+            continue;
+        };
+
+        // Avoid branching as much as possible
+        bounds!(ctx, Ethernet::MIN_LEN + IPv4::MIN_LEN + Tcp::MIN_LEN).or_drop()?;
+        let source_ip = ip4.source_u32();
+        let dest_ip = ip4.destination_u32();
+
+        // Avoid branching as much as possible
+        bounds!(ctx, eth.size_usize() + ip4.size_usize() + Tcp::MIN_LEN).or_drop()?;
+        let source = tcp.source();
+        let dest = tcp.destination();
+
+        let (ip, port) = if rule.applies_to == Direction::Source {
+            (source_ip, source)
+        } else {
+            (dest_ip, dest)
+        };
+
+        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::from_bits(ip)), port);
+
+        if let FirewallMatch::Port(rule_port) = rule.matches {
+            if rule_port == port {
+                return emit(ctx, rule.action, Some((i, socket_addr)));
             }
         }
     }

--- a/firewall/Cargo.toml
+++ b/firewall/Cargo.toml
@@ -14,7 +14,7 @@ env_logger = "0.10"
 libc = "0.2"
 log = "0.4"
 tokio = { version = "1.25", features = ["macros", "rt", "rt-multi-thread", "net", "signal", "sync", "time", "fs"] }
-netp.workspace = true
+netp.path = "../netp"
 bstr.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/netp/Cargo.toml
+++ b/netp/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "netp"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+aya-ebpf-bindings = { version = "0.1.0", optional = true }
+etherparse = { version = "0.15.0", default-features = false }
+schemars = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+
+[features]
+default = []
+aya = ["dep:aya-ebpf-bindings"]
+serde = ["dep:serde"]
+schemars = ["dep:schemars"]
+schema = ["serde", "dep:schemars"]

--- a/netp/README.md
+++ b/netp/README.md
@@ -1,0 +1,11 @@
+# netp
+
+A dead simple network packet parser.
+
+## About
+
+
+
+## Acknowledgements 
+
+## License

--- a/netp/src/aya.rs
+++ b/netp/src/aya.rs
@@ -1,0 +1,72 @@
+use aya_ebpf_bindings::bindings::xdp_action;
+
+pub struct BoundsError;
+
+#[macro_export]
+macro_rules! bounds {
+    ($ctx:expr, $size:expr) => {
+        if ($ctx.data() + $size > $ctx.data_end()) {
+            Err($crate::aya::BoundsError)
+        } else {
+            Ok(())
+        }
+    };
+}
+
+#[inline(always)]
+pub fn csum_fold_helper(mut csum: u64) -> u16 {
+    for _i in 0..4 {
+        if (csum >> 16) > 0 {
+            csum = (csum & 0xffff) + (csum >> 16);
+        }
+    }
+    !(csum as u16)
+}
+
+#[inline(always)]
+pub fn csum_diff<T: Copy>(mut old: T, mut new: T, seed: u32) -> u64 {
+    unsafe {
+        aya_ebpf_bindings::helpers::bpf_csum_diff(
+            (&mut old) as *mut T as *mut _,
+            size_of::<T>() as u32,
+            (&mut new) as *mut T as *mut _,
+            size_of::<T>() as u32,
+            seed,
+        ) as u64
+    }
+}
+
+pub trait XdpErr<T> {
+    fn or_drop(self) -> Result<T, u32>
+    where
+        T: core::marker::Sized;
+    fn or_pass(self) -> Result<T, u32>
+    where
+        T: core::marker::Sized;
+    fn or_abort(self) -> Result<T, u32>
+    where
+        T: core::marker::Sized;
+}
+
+impl<T, E> XdpErr<T> for Result<T, E> {
+    fn or_drop(self) -> Result<T, u32>
+    where
+        T: core::marker::Sized,
+    {
+        self.map_err(|_| xdp_action::XDP_DROP)
+    }
+
+    fn or_pass(self) -> Result<T, u32>
+    where
+        T: core::marker::Sized,
+    {
+        self.map_err(|_| xdp_action::XDP_PASS)
+    }
+
+    fn or_abort(self) -> Result<T, u32>
+    where
+        T: core::marker::Sized,
+    {
+        self.map_err(|_| xdp_action::XDP_ABORTED)
+    }
+}

--- a/netp/src/lib.rs
+++ b/netp/src/lib.rs
@@ -1,0 +1,8 @@
+#![cfg_attr(not(feature = "schema"), no_std)]
+
+pub mod link;
+pub mod network;
+pub mod transport;
+
+#[cfg(feature = "aya")]
+pub mod aya;

--- a/netp/src/link/eth.rs
+++ b/netp/src/link/eth.rs
@@ -1,0 +1,287 @@
+pub struct Ethernet<P = ()> {
+    slice: P,
+    size: EtherSize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u16)]
+pub enum EtherType {
+    IPv4 = 0x0800,
+    IPv6 = 0x86dd,
+    Arp = 0x0806,
+    WakeOnLan = 0x0842,
+    VlanTaggedFrame = 0x8100,
+    ProviderBridging = 0x88A8,
+    VlanDoubleTaggedFrame = 0x9100,
+    Other(u16),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[repr(usize)]
+pub enum EtherSize {
+    S18 = 18,
+    S16 = 16,
+    S14 = 14,
+}
+
+impl From<EtherType> for u16 {
+    fn from(value: EtherType) -> Self {
+        match value {
+            EtherType::IPv4 => 0x0800,
+            EtherType::IPv6 => 0x86dd,
+            EtherType::Arp => 0x0806,
+            EtherType::WakeOnLan => 0x0842,
+            EtherType::VlanTaggedFrame => 0x8100,
+            EtherType::ProviderBridging => 0x88A8,
+            EtherType::VlanDoubleTaggedFrame => 0x9100,
+            EtherType::Other(v) => v,
+        }
+    }
+}
+
+impl From<[u8; 2]> for EtherType {
+    fn from(value: [u8; 2]) -> Self {
+        let num = u16::from_be_bytes(value);
+        EtherType::from(num)
+    }
+}
+
+impl TryFrom<&[u8]> for EtherType {
+    type Error = ();
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() < 2 {
+            return Err(());
+        }
+
+        let array = *value.first_chunk::<2>().unwrap();
+        Ok(EtherType::from(array))
+    }
+}
+
+impl From<u16> for EtherType {
+    fn from(value: u16) -> Self {
+        match value {
+            0x0800 => Self::IPv4,
+            0x86dd => Self::IPv6,
+            0x0806 => Self::Arp,
+            0x0842 => Self::WakeOnLan,
+            0x8100 => Self::VlanTaggedFrame,
+            0x88A8 => Self::ProviderBridging,
+            0x9100 => Self::VlanDoubleTaggedFrame,
+            x => Self::Other(x),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Error {
+    WrongSize(usize),
+    WrongSizeForType(EtherType, usize),
+}
+
+impl<P: AsMut<[u8]> + AsRef<[u8]>> Ethernet<P> {
+    pub fn set_destination(&mut self, new_dest: &[u8; 6]) {
+        self.slice.as_mut()[0..6].copy_from_slice(new_dest);
+    }
+
+    pub fn set_source(&mut self, new_dest: &[u8; 6]) {
+        self.slice.as_mut()[6..12].copy_from_slice(new_dest);
+    }
+
+    pub fn set_ethertype(&mut self, ethertype: EtherType) {
+        self.slice.as_mut()[self.size as usize - 2..self.size as usize]
+            .copy_from_slice(&u16::from(ethertype).to_be_bytes());
+    }
+
+    pub fn slice_mut(&mut self) -> &mut [u8] {
+        self.slice.as_mut()
+    }
+}
+
+impl Ethernet<()> {
+    pub const MIN_LEN: usize = 14;
+    pub const MAX_LEN: usize = 18;
+}
+
+impl<'pkt> Ethernet<&'pkt [u8]> {
+    pub fn new(slice: &'pkt [u8]) -> Result<(Ethernet<&'pkt [u8]>, &'pkt [u8]), Error> {
+        if slice.len() < Ethernet::MIN_LEN {
+            return Err(Error::WrongSize(slice.len()));
+        }
+
+        let size = match EtherType::from(*slice[12..14].first_chunk::<2>().unwrap()) {
+            EtherType::VlanDoubleTaggedFrame if slice.len() >= Ethernet::MAX_LEN => EtherSize::S18,
+            EtherType::VlanTaggedFrame if slice.len() >= Ethernet::MIN_LEN + 2 => EtherSize::S16,
+            EtherType::Other(_) if slice.len() >= Ethernet::MIN_LEN => EtherSize::S14,
+            _ if slice.len() >= Ethernet::MIN_LEN => EtherSize::S14,
+            x => return Err(Error::WrongSizeForType(x, slice.len())),
+        };
+
+        let (parsed, rem) = slice.split_at(size as usize);
+        Ok((
+            Ethernet {
+                slice: parsed,
+                size,
+            },
+            rem,
+        ))
+    }
+}
+
+impl<'pkt> Ethernet<&'pkt mut [u8]> {
+    pub fn new_mut(
+        slice: &'pkt mut [u8],
+    ) -> Result<(Ethernet<&'pkt mut [u8]>, &'pkt mut [u8]), Error> {
+        if slice.len() < Ethernet::MIN_LEN {
+            return Err(Error::WrongSize(slice.len()));
+        }
+
+        let size = match EtherType::from(*slice[12..14].first_chunk::<2>().unwrap()) {
+            EtherType::VlanDoubleTaggedFrame if slice.len() >= Ethernet::MAX_LEN => EtherSize::S18,
+            EtherType::VlanTaggedFrame if slice.len() >= Ethernet::MIN_LEN + 2 => EtherSize::S16,
+            EtherType::Other(_) if slice.len() >= Ethernet::MIN_LEN => EtherSize::S14,
+            _ if slice.len() >= Ethernet::MIN_LEN => EtherSize::S14,
+            x => return Err(Error::WrongSizeForType(x, slice.len())),
+        };
+
+        let (parsed, rem) = slice.split_at_mut(size as usize);
+        Ok((
+            Ethernet {
+                slice: parsed,
+                size,
+            },
+            rem,
+        ))
+    }
+}
+
+impl<P: AsRef<[u8]>> Ethernet<P> {
+    pub fn ethertype(&self) -> EtherType {
+        match self.size {
+            EtherSize::S18 => {
+                EtherType::from(*self.slice.as_ref()[16..18].first_chunk::<2>().unwrap())
+            }
+            EtherSize::S16 => {
+                EtherType::from(*self.slice.as_ref()[14..16].first_chunk::<2>().unwrap())
+            }
+            EtherSize::S14 => {
+                EtherType::from(*self.slice.as_ref()[12..14].first_chunk::<2>().unwrap())
+            }
+        }
+    }
+
+    pub fn destination(&self) -> &[u8; 6] {
+        self.slice.as_ref()[0..6].try_into().unwrap()
+    }
+
+    pub fn slice(&self) -> &[u8] {
+        self.slice.as_ref()
+    }
+
+    pub fn size_usize(&self) -> usize {
+        match self.size {
+            EtherSize::S18 => 18,
+            EtherSize::S16 => 16,
+            EtherSize::S14 => 14,
+        }
+    }
+
+    pub fn size(&self) -> EtherSize {
+        self.size
+    }
+
+    pub fn source(&self) -> &[u8; 6] {
+        self.slice.as_ref()[6..12].try_into().unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::link::eth::EtherSize;
+    use crate::link::{EtherType, Ethernet};
+
+    #[test]
+    fn create_mut() {
+        let mut packet = [
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x08, 0x00,
+        ];
+        let (mut eth, rem) = Ethernet::new_mut(&mut packet).unwrap();
+
+        assert_eq!(rem.len(), 0);
+        assert_eq!(eth.destination(), &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        assert_eq!(eth.source(), &[0x01, 0x01, 0x01, 0x01, 0x01, 0x01]);
+        assert_eq!(eth.ethertype(), EtherType::IPv4);
+
+        eth.set_source(&[0x02, 0x02, 0x02, 0x02, 0x02, 0x02]);
+        eth.set_destination(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+
+        assert_eq!(eth.source(), &[0x02, 0x02, 0x02, 0x02, 0x02, 0x02]);
+        assert_eq!(eth.destination(), &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+    }
+
+    #[test]
+    fn create_ref() {
+        let packet = [
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x08, 0x00,
+        ];
+        let (eth, rem) = Ethernet::new(&packet).unwrap();
+
+        assert_eq!(rem.len(), 0);
+        assert_eq!(eth.size, EtherSize::S14);
+        assert_eq!(eth.destination(), &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        assert_eq!(eth.source(), &[0x01, 0x01, 0x01, 0x01, 0x01, 0x01]);
+        assert_eq!(eth.ethertype(), EtherType::IPv4);
+    }
+
+    #[test]
+    fn vlan_tagged() {
+        let packet = [
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x81, 0x00,
+            0x08, 0x00,
+        ];
+        let (eth, rem) = Ethernet::new(&packet).unwrap();
+
+        assert_eq!(rem.len(), 0);
+        assert_eq!(eth.size, EtherSize::S16);
+        assert_eq!(eth.destination(), &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        assert_eq!(eth.source(), &[0x01, 0x01, 0x01, 0x01, 0x01, 0x01]);
+        assert_eq!(eth.ethertype(), EtherType::IPv4);
+    }
+
+    #[test]
+    fn double_vlan_tagged() {
+        let packet = [
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x91, 0x00,
+            0x81, 0x00, 0x08, 0x00,
+        ];
+        let (eth, rem) = Ethernet::new(&packet).unwrap();
+
+        assert_eq!(rem.len(), 0);
+        assert_eq!(eth.size, EtherSize::S18);
+        assert_eq!(eth.destination(), &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        assert_eq!(eth.source(), &[0x01, 0x01, 0x01, 0x01, 0x01, 0x01]);
+        assert_eq!(eth.ethertype(), EtherType::IPv4);
+    }
+
+    #[test]
+    fn change_ehertype() {
+        let mut packet = [
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x81, 0x00,
+            0x08, 0x00,
+        ];
+        let (mut eth, rem) = Ethernet::new_mut(&mut packet).unwrap();
+
+        assert_eq!(rem.len(), 0);
+        assert_eq!(eth.size, EtherSize::S16);
+        assert_eq!(eth.destination(), &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        assert_eq!(eth.source(), &[0x01, 0x01, 0x01, 0x01, 0x01, 0x01]);
+        assert_eq!(eth.ethertype(), EtherType::IPv4);
+
+        eth.set_ethertype(EtherType::Arp);
+
+        assert_eq!(eth.size, EtherSize::S16);
+        assert_eq!(eth.destination(), &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        assert_eq!(eth.source(), &[0x01, 0x01, 0x01, 0x01, 0x01, 0x01]);
+        assert_eq!(eth.ethertype(), EtherType::Arp);
+    }
+}

--- a/netp/src/link/mod.rs
+++ b/netp/src/link/mod.rs
@@ -1,0 +1,2 @@
+pub mod eth;
+pub use eth::{Ethernet, EtherType};

--- a/netp/src/network/ipnum.rs
+++ b/netp/src/network/ipnum.rs
@@ -1,0 +1,600 @@
+#[allow(non_camel_case_types)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[repr(u8)]
+pub enum InetProtocol {
+    /// IPv6 Hop-by-Hop Option \[[RFC8200](https://datatracker.ietf.org/doc/html/rfc8200)\]
+    IPV6_HEADER_HOP_BY_HOP = 0,
+    /// Internet Control Message \[[RFC792](https://datatracker.ietf.org/doc/html/rfc792)\]
+    ICMP = 1,
+    /// Internet Group Management \[[RFC1112](https://datatracker.ietf.org/doc/html/rfc1112)\]
+    IGMP = 2,
+    /// Gateway-to-Gateway \[[RFC823](https://datatracker.ietf.org/doc/html/rfc823)\]
+    GGP = 3,
+    /// IPv4 encapsulation \[[RFC2003](https://datatracker.ietf.org/doc/html/rfc2003)\]
+    IPV4 = 4,
+    /// Stream \[[RFC1190](https://datatracker.ietf.org/doc/html/rfc1190)\] \[[RFC1819](https://datatracker.ietf.org/doc/html/rfc1819)\]
+    STREAM = 5,
+    /// Transmission Control \[[RFC793](https://datatracker.ietf.org/doc/html/rfc793)\]
+    TCP = 6,
+    /// CBT \[Tony_Ballardie\]
+    CBT = 7,
+    /// Exterior Gateway Protocol \[[RFC888](https://datatracker.ietf.org/doc/html/rfc888)\] \[David_Mills\]
+    EGP = 8,
+    /// any private interior gateway (used by Cisco for their IGRP) \[Internet_Assigned_Numbers_Authority\]
+    IGP = 9,
+    /// BBN RCC Monitoring \[Steve_Chipman\]
+    BBN_RCC_MON = 10,
+    /// Network Voice Protocol \[[RFC741](https://datatracker.ietf.org/doc/html/rfc741)\]\[Steve_Casner\]
+    NVP_II = 11,
+    /// PUP
+    PUP = 12,
+    /// ARGUS (deprecated) \[Robert_W_Scheifler\]
+    ARGUS = 13,
+    /// EMCON \[mystery contact\]
+    EMCON = 14,
+    /// Cross Net Debugger \[Haverty, J., "XNET Formats for Internet Protocol Version 4", IEN 158, October 1980.\]\[Jack_Haverty\]
+    XNET = 15,
+    /// Chaos \[J_Noel_Chiappa\]
+    CHAOS = 16,
+    /// User Datagram \[[RFC768](https://datatracker.ietf.org/doc/html/rfc768)\]\[Jon_Postel\]
+    UDP = 17,
+    /// Multiplexing \[Cohen, D. and J. Postel, "Multiplexing Protocol", IEN 90, USC/Information Sciences Institute, May 1979.\]\[Jon_Postel\]
+    MUX = 18,
+    /// DCN Measurement Subsystems \[David_Mills\]
+    DCN_MEAS = 19,
+    /// Host Monitoring \[[RFC869](https://datatracker.ietf.org/doc/html/rfc869)\]\[Bob_Hinden\]
+    HMP = 20,
+    /// Packet Radio Measurement \[Zaw_Sing_Su\]
+    PRM = 21,
+    /// XEROX NS IDP
+    XNS_IDP = 22,
+    /// Trunk-1 \[Barry_Boehm\]
+    TRUNK1 = 23,
+    /// Trunk-2 \[Barry_Boehm\]
+    TRUNK2 = 24,
+    /// Leaf-1 \[Barry_Boehm\]
+    LEAF1 = 25,
+    /// Leaf-2 \[Barry_Boehm\]
+    LEAF2 = 26,
+    /// Reliable Data Protocol \[[RFC908](https://datatracker.ietf.org/doc/html/rfc908)\] \[Bob_Hinden\]
+    RDP = 27,
+    /// Internet Reliable Transaction \[[RFC938](https://datatracker.ietf.org/doc/html/rfc938)\] \[Trudy_Miller\]
+    IRTP = 28,
+    /// ISO Transport Protocol Class 4 \[[RFC905](https://datatracker.ietf.org/doc/html/rfc905)\] \[mystery contact\]
+    ISO_TP4 = 29,
+    /// Bulk Data Transfer Protocol \[[RFC969](https://datatracker.ietf.org/doc/html/rfc969)\] \[David_Clark\]
+    NET_BLT = 30,
+    /// MFE Network Services Protocol \[Shuttleworth, B., "A Documentary of MFENet, a National Computer Network", UCRL-52317, Lawrence Livermore Labs, Livermore, California, June 1977.\] \[Barry_Howard\]
+    MFE_NSP = 31,
+    /// MERIT Internodal Protocol \[Hans_Werner_Braun\]
+    MERIT_INP = 32,
+    /// Datagram Congestion Control Protocol \[[RFC4340](https://datatracker.ietf.org/doc/html/rfc4340)\]
+    DCCP = 33,
+    /// Third Party Connect Protocol \[Stuart_A_Friedberg\]
+    THIRD_PARTY_CONNECT_PROTOCOL = 34,
+    /// Inter-Domain Policy Routing Protocol \[Martha_Steenstrup\]
+    IDPR = 35,
+    /// XTP \[Greg_Chesson\]
+    XTP = 36,
+    /// Datagram Delivery Protocol \[Wesley_Craig\]
+    DDP = 37,
+    /// IDPR Control Message Transport Proto \[Martha_Steenstrup\]
+    IDPR_CMTP = 38,
+    /// TP++ Transport Protocol \[Dirk_Fromhein\]
+    TP_PLUS_PLUS = 39,
+    /// IL Transport Protocol \[Dave_Presotto\]
+    IL = 40,
+    /// IPv6 encapsulation \[[RFC2473](https://datatracker.ietf.org/doc/html/rfc2473)\]
+    IPV6 = 41,
+    /// Source Demand Routing Protocol \[Deborah_Estrin\]
+    SDRP = 42,
+    /// Routing Header for IPv6 \[Steve_Deering\]
+    IPV6_ROUTE_HEADER = 43,
+    /// Fragment Header for IPv6 \[Steve_Deering\]
+    IPV6_FRAGMENTATION_HEADER = 44,
+    /// Inter-Domain Routing Protocol \[Sue_Hares\]
+    IDRP = 45,
+    /// Reservation Protocol \[[RFC2205](https://datatracker.ietf.org/doc/html/rfc2205)\]\[[RFC3209](https://datatracker.ietf.org/doc/html/rfc3209)\]\[Bob_Braden\]
+    RSVP = 46,
+    /// Generic Routing Encapsulation \[[RFC2784](https://datatracker.ietf.org/doc/html/rfc2784)\]\[Tony_Li\]
+    GRE = 47,
+    /// Dynamic Source Routing Protocol \[[RFC4728](https://datatracker.ietf.org/doc/html/rfc4728)\]
+    DSR = 48,
+    /// BNA \[Gary Salamon\]
+    BNA = 49,
+    /// Encapsulating Security Payload \[[RFC4303](https://datatracker.ietf.org/doc/html/rfc4303)\]
+    ENCAPSULATING_SECURITY_PAYLOAD = 50,
+    /// Authentication Header \[[RFC4302](https://datatracker.ietf.org/doc/html/rfc4302)\]
+    AUTHENTICATION_HEADER = 51,
+    /// Integrated Net Layer Security  TUBA \[K_Robert_Glenn\]
+    INLSP = 52,
+    /// IP with Encryption (deprecated) \[John_Ioannidis\]
+    SWIPE = 53,
+    /// NBMA Address Resolution Protocol \[[RFC1735](https://datatracker.ietf.org/doc/html/rfc1735)\]
+    NARP = 54,
+    /// IP Mobility \[Charlie_Perkins\]
+    MOBILE = 55,
+    /// Transport Layer Security Protocol using Kryptonet key management \[Christer_Oberg\]
+    TLSP = 56,
+    /// SKIP \[Tom_Markson\]
+    SKIP = 57,
+    /// ICMP for IPv6 \[[RFC8200](https://datatracker.ietf.org/doc/html/rfc8200)\]
+    IPV6_ICMP = 58,
+    /// No Next Header for IPv6 \[[RFC8200](https://datatracker.ietf.org/doc/html/rfc8200)\]
+    IPV6_NO_NEXT_HEADER = 59,
+    /// Destination Options for IPv6 \[[RFC8200](https://datatracker.ietf.org/doc/html/rfc8200)\]
+    IPV6_DESTINATION_OPTIONS = 60,
+    /// any host internal protocol \[Internet_Assigned_Numbers_Authority\]
+    ANY_HOST_INTERNAL_PROTOCOL = 61,
+    /// CFTP \[Forsdick, H., "CFTP", Network Message, Bolt Beranek and Newman, January 1982.\]\[Harry_Forsdick\]
+    CFTP = 62,
+    /// any local network \[Internet_Assigned_Numbers_Authority\]
+    ANY_LOCAL_NETWORK = 63,
+    /// SATNET and Backroom EXPAK \[Steven_Blumenthal\]
+    SAT_EXPAK = 64,
+    /// Kryptolan \[Paul Liu\]
+    KRYTOLAN = 65,
+    /// MIT Remote Virtual Disk Protocol \[Michael_Greenwald\]
+    RVD = 66,
+    /// Internet Pluribus Packet Core \[Steven_Blumenthal\]
+    IPPC = 67,
+    /// any distributed file system \[Internet_Assigned_Numbers_Authority\]
+    ANY_DISTRIBUTED_FILE_SYSTEM = 68,
+    /// SATNET Monitoring \[Steven_Blumenthal\]
+    SAT_MON = 69,
+    /// VISA Protocol \[Gene_Tsudik\]
+    VISA = 70,
+    /// Internet Packet Core Utility \[Steven_Blumenthal\]
+    IPCV = 71,
+    /// Computer Protocol Network Executive \[David Mittnacht\]
+    CPNX = 72,
+    /// Computer Protocol Heart Beat \[David Mittnacht\]
+    CPHB = 73,
+    /// Wang Span Network \[Victor Dafoulas\]
+    WSN = 74,
+    /// Packet Video Protocol \[Steve_Casner\]
+    PVP = 75,
+    /// Backroom SATNET Monitoring \[Steven_Blumenthal\]
+    BR_SAT_MON = 76,
+    /// SUN ND PROTOCOL-Temporary \[William_Melohn\]
+    SUN_ND = 77,
+    /// WIDEBAND Monitoring \[Steven_Blumenthal\]
+    WB_MON = 78,
+    /// WIDEBAND EXPAK \[Steven_Blumenthal\]
+    WB_EXPAK = 79,
+    /// ISO Internet Protocol \[Marshall_T_Rose\]
+    ISO_IP = 80,
+    /// VMTP \[Dave_Cheriton\]
+    VMTP = 81,
+    /// SECURE-VMTP \[Dave_Cheriton\]
+    SECURE_VMTP = 82,
+    /// VINES \[Brian Horn\]
+    VINES = 83,
+    /// Transaction Transport Protocol or Internet Protocol Traffic Manager \[Jim_Stevens\]
+    TTP_OR_IPTM = 84,
+    /// NSFNET-IGP \[Hans_Werner_Braun\]
+    NSFNET_IGP = 85,
+    /// Dissimilar Gateway Protocol \[M/A-COM Government Systems, "Dissimilar Gateway Protocol Specification, Draft Version", Contract no. CS901145, November 16, 1987.\]\[Mike_Little\]
+    DGP = 86,
+    /// TCF \[Guillermo_A_Loyola\]
+    TCF = 87,
+    /// EIGRP \[[RFC7868](https://datatracker.ietf.org/doc/html/rfc7868)\]
+    EIGRP = 88,
+    /// OSPFIGP \[[RFC1583](https://datatracker.ietf.org/doc/html/rfc1583)\]\[[RFC2328](https://datatracker.ietf.org/doc/html/rfc2328)\]\[[RFC5340](https://datatracker.ietf.org/doc/html/rfc5340)\]\[John_Moy\]
+    OSPFIGP = 89,
+    /// Sprite RPC Protocol \[Welch, B., "The Sprite Remote Procedure Call System", Technical Report, UCB/Computer Science Dept., 86/302, University of California at Berkeley, June 1986.\]\[Bruce Willins\]
+    SPRITE_RPC = 90,
+    /// Locus Address Resolution Protocol \[Brian Horn\]
+    LARP = 91,
+    /// Multicast Transport Protocol \[Susie_Armstrong\]
+    MTP = 92,
+    /// AX.25 Frames \[Brian_Kantor\]
+    AX25 = 93,
+    /// IP-within-IP Encapsulation Protocol \[John_Ioannidis\]
+    IPIP = 94,
+    /// Mobile Internetworking Control Pro. (deprecated) \[John_Ioannidis\]
+    MICP = 95,
+    /// Semaphore Communications Sec. Pro. \[Howard_Hart\]
+    SCC_SP = 96,
+    /// Ethernet-within-IP Encapsulation \[[RFC3378](https://datatracker.ietf.org/doc/html/rfc3378)\]
+    ETHER_IP = 97,
+    /// Encapsulation Header \[[RFC1241](https://datatracker.ietf.org/doc/html/rfc1241)\]\[Robert_Woodburn\]
+    ENCAP = 98,
+    /// GMTP \[\[RXB5\]\]
+    GMTP = 100,
+    /// Ipsilon Flow Management Protocol \[Bob_Hinden\]\[November 1995, 1997.\]
+    IFMP = 101,
+    /// PNNI over IP \[Ross_Callon\]
+    PNNI = 102,
+    /// Protocol Independent Multicast \[[RFC7761](https://datatracker.ietf.org/doc/html/rfc7761)\]\[Dino_Farinacci\]
+    PIM = 103,
+    /// ARIS \[Nancy_Feldman\]
+    ARIS = 104,
+    /// SCPS \[Robert_Durst\]
+    SCPS = 105,
+    /// QNX \[Michael_Hunter\]
+    QNX = 106,
+    /// Active Networks \[Bob_Braden\]
+    ACTIVE_NETWORKS = 107,
+    /// IP Payload Compression Protocol \[[RFC2393](https://datatracker.ietf.org/doc/html/rfc2393)\]
+    IP_COMP = 108,
+    /// Sitara Networks Protocol \[Manickam_R_Sridhar\]
+    SITRA_NETWORKS_PROTOCOL = 109,
+    /// Compaq Peer Protocol \[Victor_Volpe\]
+    COMPAQ_PEER = 110,
+    /// IPX in IP \[CJ_Lee\]
+    IPX_IN_IP = 111,
+    /// Virtual Router Redundancy Protocol \[[RFC5798](https://datatracker.ietf.org/doc/html/rfc5798)\]
+    VRRP = 112,
+    /// PGM Reliable Transport Protocol \[Tony_Speakman\]
+    PGM = 113,
+    /// any 0-hop protocol \[Internet_Assigned_Numbers_Authority\]
+    ANY_ZERO_HOP_PROTOCOL = 114,
+    /// Layer Two Tunneling Protocol \[[RFC3931](https://datatracker.ietf.org/doc/html/rfc3931)\]\[Bernard_Aboba\]
+    LAYER2_TUNNELING_PROTOCOL = 115,
+    /// D-II Data Exchange (DDX) \[John_Worley\]
+    DDX = 116,
+    /// Interactive Agent Transfer Protocol \[John_Murphy\]
+    IATP = 117,
+    /// Schedule Transfer Protocol \[Jean_Michel_Pittet\]
+    STP = 118,
+    /// SpectraLink Radio Protocol \[Mark_Hamilton\]
+    SRP = 119,
+    /// UTI \[Peter_Lothberg\]
+    UTI = 120,
+    /// Simple Message Protocol \[Leif_Ekblad\]
+    SIMPLE_MESSAGE_PROTOCOL = 121,
+    /// Simple Multicast Protocol (deprecated) \[Jon_Crowcroft\]\[draft-perlman-simple-multicast\]
+    SM = 122,
+    /// Performance Transparency Protocol \[Michael_Welzl\]
+    PTP = 123,
+    /// ISIS over IPv4 \[Tony_Przygienda\]
+    ISIS_OVER_IPV4 = 124,
+    /// FIRE \[Criag_Partridge\]
+    FIRE = 125,
+    /// Combat Radio Transport Protocol \[Robert_Sautter\]
+    CRTP = 126,
+    /// Combat Radio User Datagram \[Robert_Sautter\]
+    CRUDP = 127,
+    /// SSCOPMCE \[Kurt_Waber\]
+    SSCOPMCE = 128,
+    /// IPLT \[\[Hollbach\]\]
+    IPLT = 129,
+    /// Secure Packet Shield \[Bill_McIntosh\]
+    SPS = 130,
+    /// Private IP Encapsulation within IP \[Bernhard_Petri\]
+    PIPE = 131,
+    /// Stream Control Transmission Protocol \[Randall_R_Stewart\]
+    SCTP = 132,
+    /// Fibre Channel \[Murali_Rajagopal\]\[[RFC6172](https://datatracker.ietf.org/doc/html/rfc6172)\]
+    FC = 133,
+    /// RSVP-E2E-IGNORE \[[RFC3175](https://datatracker.ietf.org/doc/html/rfc3175)\]
+    RSVP_E2E_IGNORE = 134,
+    /// MobilityHeader \[[RFC6275](https://datatracker.ietf.org/doc/html/rfc6275)\]
+    MOBILITY_HEADER = 135,
+    /// UDPLite \[[RFC3828](https://datatracker.ietf.org/doc/html/rfc3828)\]
+    UDP_LITE = 136,
+    /// \[[RFC4023](https://datatracker.ietf.org/doc/html/rfc4023)\]
+    MPLS_IN_IP = 137,
+    /// MANET Protocols \[[RFC5498](https://datatracker.ietf.org/doc/html/rfc5498)\]
+    MANET = 138,
+    /// Host Identity Protocol \[[RFC7401](https://datatracker.ietf.org/doc/html/rfc7401)\]
+    HIP = 139,
+    /// Shim6 Protocol \[[RFC5533](https://datatracker.ietf.org/doc/html/rfc5533)\]
+    SHIM6 = 140,
+    /// Wrapped Encapsulating Security Payload \[[RFC5840](https://datatracker.ietf.org/doc/html/rfc5840)\]
+    WESP = 141,
+    /// Robust Header Compression \[[RFC5858](https://datatracker.ietf.org/doc/html/rfc5858)\]
+    ROHC = 142,
+    /// Use for experimentation and testing
+    EXPERIMENTAL_AND_TESTING_0 = 253,
+    /// Use for experimentation and testing
+    EXPERIMENTAL_AND_TESTING_1 = 254,
+    Other(u8),
+}
+
+impl From<u8> for InetProtocol {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => Self::IPV6_HEADER_HOP_BY_HOP,
+            1 => Self::ICMP,
+            2 => Self::IGMP,
+            3 => Self::GGP,
+            4 => Self::IPV4,
+            5 => Self::STREAM,
+            6 => Self::TCP,
+            7 => Self::CBT,
+            8 => Self::EGP,
+            9 => Self::IGP,
+            10 => Self::BBN_RCC_MON,
+            11 => Self::NVP_II,
+            12 => Self::PUP,
+            13 => Self::ARGUS,
+            14 => Self::EMCON,
+            15 => Self::XNET,
+            16 => Self::CHAOS,
+            17 => Self::UDP,
+            18 => Self::MUX,
+            19 => Self::DCN_MEAS,
+            20 => Self::HMP,
+            21 => Self::PRM,
+            22 => Self::XNS_IDP,
+            23 => Self::TRUNK1,
+            24 => Self::TRUNK2,
+            25 => Self::LEAF1,
+            26 => Self::LEAF2,
+            27 => Self::RDP,
+            28 => Self::IRTP,
+            29 => Self::ISO_TP4,
+            30 => Self::NET_BLT,
+            31 => Self::MFE_NSP,
+            32 => Self::MERIT_INP,
+            33 => Self::DCCP,
+            34 => Self::THIRD_PARTY_CONNECT_PROTOCOL,
+            35 => Self::IDPR,
+            36 => Self::XTP,
+            37 => Self::DDP,
+            38 => Self::IDPR_CMTP,
+            39 => Self::TP_PLUS_PLUS,
+            40 => Self::IL,
+            41 => Self::IPV6,
+            42 => Self::SDRP,
+            43 => Self::IPV6_ROUTE_HEADER,
+            44 => Self::IPV6_FRAGMENTATION_HEADER,
+            45 => Self::IDRP,
+            46 => Self::RSVP,
+            47 => Self::GRE,
+            48 => Self::DSR,
+            49 => Self::BNA,
+            50 => Self::ENCAPSULATING_SECURITY_PAYLOAD,
+            51 => Self::AUTHENTICATION_HEADER,
+            52 => Self::INLSP,
+            53 => Self::SWIPE,
+            54 => Self::NARP,
+            55 => Self::MOBILE,
+            56 => Self::TLSP,
+            57 => Self::SKIP,
+            58 => Self::IPV6_ICMP,
+            59 => Self::IPV6_NO_NEXT_HEADER,
+            60 => Self::IPV6_DESTINATION_OPTIONS,
+            61 => Self::ANY_HOST_INTERNAL_PROTOCOL,
+            62 => Self::CFTP,
+            63 => Self::ANY_LOCAL_NETWORK,
+            64 => Self::SAT_EXPAK,
+            65 => Self::KRYTOLAN,
+            66 => Self::RVD,
+            67 => Self::IPPC,
+            68 => Self::ANY_DISTRIBUTED_FILE_SYSTEM,
+            69 => Self::SAT_MON,
+            70 => Self::VISA,
+            71 => Self::IPCV,
+            72 => Self::CPNX,
+            73 => Self::CPHB,
+            74 => Self::WSN,
+            75 => Self::PVP,
+            76 => Self::BR_SAT_MON,
+            77 => Self::SUN_ND,
+            78 => Self::WB_MON,
+            79 => Self::WB_EXPAK,
+            80 => Self::ISO_IP,
+            81 => Self::VMTP,
+            82 => Self::SECURE_VMTP,
+            83 => Self::VINES,
+            84 => Self::TTP_OR_IPTM,
+            85 => Self::NSFNET_IGP,
+            86 => Self::DGP,
+            87 => Self::TCF,
+            88 => Self::EIGRP,
+            89 => Self::OSPFIGP,
+            90 => Self::SPRITE_RPC,
+            91 => Self::LARP,
+            92 => Self::MTP,
+            93 => Self::AX25,
+            94 => Self::IPIP,
+            95 => Self::MICP,
+            96 => Self::SCC_SP,
+            97 => Self::ETHER_IP,
+            98 => Self::ENCAP,
+            100 => Self::GMTP,
+            101 => Self::IFMP,
+            102 => Self::PNNI,
+            103 => Self::PIM,
+            104 => Self::ARIS,
+            105 => Self::SCPS,
+            106 => Self::QNX,
+            107 => Self::ACTIVE_NETWORKS,
+            108 => Self::IP_COMP,
+            109 => Self::SITRA_NETWORKS_PROTOCOL,
+            110 => Self::COMPAQ_PEER,
+            111 => Self::IPX_IN_IP,
+            112 => Self::VRRP,
+            113 => Self::PGM,
+            114 => Self::ANY_ZERO_HOP_PROTOCOL,
+            115 => Self::LAYER2_TUNNELING_PROTOCOL,
+            116 => Self::DDX,
+            117 => Self::IATP,
+            118 => Self::STP,
+            119 => Self::SRP,
+            120 => Self::UTI,
+            121 => Self::SIMPLE_MESSAGE_PROTOCOL,
+            122 => Self::SM,
+            123 => Self::PTP,
+            124 => Self::ISIS_OVER_IPV4,
+            125 => Self::FIRE,
+            126 => Self::CRTP,
+            127 => Self::CRUDP,
+            128 => Self::SSCOPMCE,
+            129 => Self::IPLT,
+            130 => Self::SPS,
+            131 => Self::PIPE,
+            132 => Self::SCTP,
+            133 => Self::FC,
+            134 => Self::RSVP_E2E_IGNORE,
+            135 => Self::MOBILITY_HEADER,
+            136 => Self::UDP_LITE,
+            137 => Self::MPLS_IN_IP,
+            138 => Self::MANET,
+            139 => Self::HIP,
+            140 => Self::SHIM6,
+            141 => Self::WESP,
+            142 => Self::ROHC,
+            253 => Self::EXPERIMENTAL_AND_TESTING_0,
+            254 => Self::EXPERIMENTAL_AND_TESTING_1,
+            x => Self::Other(x),
+        }
+    }
+}
+
+impl From<InetProtocol> for u8 {
+    fn from(value: InetProtocol) -> Self {
+        match value {
+            InetProtocol::IPV6_HEADER_HOP_BY_HOP => 0,
+            InetProtocol::ICMP => 1,
+            InetProtocol::IGMP => 2,
+            InetProtocol::GGP => 3,
+            InetProtocol::IPV4 => 4,
+            InetProtocol::STREAM => 5,
+            InetProtocol::TCP => 6,
+            InetProtocol::CBT => 7,
+            InetProtocol::EGP => 8,
+            InetProtocol::IGP => 9,
+            InetProtocol::BBN_RCC_MON => 10,
+            InetProtocol::NVP_II => 11,
+            InetProtocol::PUP => 12,
+            InetProtocol::ARGUS => 13,
+            InetProtocol::EMCON => 14,
+            InetProtocol::XNET => 15,
+            InetProtocol::CHAOS => 16,
+            InetProtocol::UDP => 17,
+            InetProtocol::MUX => 18,
+            InetProtocol::DCN_MEAS => 19,
+            InetProtocol::HMP => 20,
+            InetProtocol::PRM => 21,
+            InetProtocol::XNS_IDP => 22,
+            InetProtocol::TRUNK1 => 23,
+            InetProtocol::TRUNK2 => 24,
+            InetProtocol::LEAF1 => 25,
+            InetProtocol::LEAF2 => 26,
+            InetProtocol::RDP => 27,
+            InetProtocol::IRTP => 28,
+            InetProtocol::ISO_TP4 => 29,
+            InetProtocol::NET_BLT => 30,
+            InetProtocol::MFE_NSP => 31,
+            InetProtocol::MERIT_INP => 32,
+            InetProtocol::DCCP => 33,
+            InetProtocol::THIRD_PARTY_CONNECT_PROTOCOL => 34,
+            InetProtocol::IDPR => 35,
+            InetProtocol::XTP => 36,
+            InetProtocol::DDP => 37,
+            InetProtocol::IDPR_CMTP => 38,
+            InetProtocol::TP_PLUS_PLUS => 39,
+            InetProtocol::IL => 40,
+            InetProtocol::IPV6 => 41,
+            InetProtocol::SDRP => 42,
+            InetProtocol::IPV6_ROUTE_HEADER => 43,
+            InetProtocol::IPV6_FRAGMENTATION_HEADER => 44,
+            InetProtocol::IDRP => 45,
+            InetProtocol::RSVP => 46,
+            InetProtocol::GRE => 47,
+            InetProtocol::DSR => 48,
+            InetProtocol::BNA => 49,
+            InetProtocol::ENCAPSULATING_SECURITY_PAYLOAD => 50,
+            InetProtocol::AUTHENTICATION_HEADER => 51,
+            InetProtocol::INLSP => 52,
+            InetProtocol::SWIPE => 53,
+            InetProtocol::NARP => 54,
+            InetProtocol::MOBILE => 55,
+            InetProtocol::TLSP => 56,
+            InetProtocol::SKIP => 57,
+            InetProtocol::IPV6_ICMP => 58,
+            InetProtocol::IPV6_NO_NEXT_HEADER => 59,
+            InetProtocol::IPV6_DESTINATION_OPTIONS => 60,
+            InetProtocol::ANY_HOST_INTERNAL_PROTOCOL => 61,
+            InetProtocol::CFTP => 62,
+            InetProtocol::ANY_LOCAL_NETWORK => 63,
+            InetProtocol::SAT_EXPAK => 64,
+            InetProtocol::KRYTOLAN => 65,
+            InetProtocol::RVD => 66,
+            InetProtocol::IPPC => 67,
+            InetProtocol::ANY_DISTRIBUTED_FILE_SYSTEM => 68,
+            InetProtocol::SAT_MON => 69,
+            InetProtocol::VISA => 70,
+            InetProtocol::IPCV => 71,
+            InetProtocol::CPNX => 72,
+            InetProtocol::CPHB => 73,
+            InetProtocol::WSN => 74,
+            InetProtocol::PVP => 75,
+            InetProtocol::BR_SAT_MON => 76,
+            InetProtocol::SUN_ND => 77,
+            InetProtocol::WB_MON => 78,
+            InetProtocol::WB_EXPAK => 79,
+            InetProtocol::ISO_IP => 80,
+            InetProtocol::VMTP => 81,
+            InetProtocol::SECURE_VMTP => 82,
+            InetProtocol::VINES => 83,
+            InetProtocol::TTP_OR_IPTM => 84,
+            InetProtocol::NSFNET_IGP => 85,
+            InetProtocol::DGP => 86,
+            InetProtocol::TCF => 87,
+            InetProtocol::EIGRP => 88,
+            InetProtocol::OSPFIGP => 89,
+            InetProtocol::SPRITE_RPC => 90,
+            InetProtocol::LARP => 91,
+            InetProtocol::MTP => 92,
+            InetProtocol::AX25 => 93,
+            InetProtocol::IPIP => 94,
+            InetProtocol::MICP => 95,
+            InetProtocol::SCC_SP => 96,
+            InetProtocol::ETHER_IP => 97,
+            InetProtocol::ENCAP => 98,
+            InetProtocol::GMTP => 100,
+            InetProtocol::IFMP => 101,
+            InetProtocol::PNNI => 102,
+            InetProtocol::PIM => 103,
+            InetProtocol::ARIS => 104,
+            InetProtocol::SCPS => 105,
+            InetProtocol::QNX => 106,
+            InetProtocol::ACTIVE_NETWORKS => 107,
+            InetProtocol::IP_COMP => 108,
+            InetProtocol::SITRA_NETWORKS_PROTOCOL => 109,
+            InetProtocol::COMPAQ_PEER => 110,
+            InetProtocol::IPX_IN_IP => 111,
+            InetProtocol::VRRP => 112,
+            InetProtocol::PGM => 113,
+            InetProtocol::ANY_ZERO_HOP_PROTOCOL => 114,
+            InetProtocol::LAYER2_TUNNELING_PROTOCOL => 115,
+            InetProtocol::DDX => 116,
+            InetProtocol::IATP => 117,
+            InetProtocol::STP => 118,
+            InetProtocol::SRP => 119,
+            InetProtocol::UTI => 120,
+            InetProtocol::SIMPLE_MESSAGE_PROTOCOL => 121,
+            InetProtocol::SM => 122,
+            InetProtocol::PTP => 123,
+            InetProtocol::ISIS_OVER_IPV4 => 124,
+            InetProtocol::FIRE => 125,
+            InetProtocol::CRTP => 126,
+            InetProtocol::CRUDP => 127,
+            InetProtocol::SSCOPMCE => 128,
+            InetProtocol::IPLT => 129,
+            InetProtocol::SPS => 130,
+            InetProtocol::PIPE => 131,
+            InetProtocol::SCTP => 132,
+            InetProtocol::FC => 133,
+            InetProtocol::RSVP_E2E_IGNORE => 134,
+            InetProtocol::MOBILITY_HEADER => 135,
+            InetProtocol::UDP_LITE => 136,
+            InetProtocol::MPLS_IN_IP => 137,
+            InetProtocol::MANET => 138,
+            InetProtocol::HIP => 139,
+            InetProtocol::SHIM6 => 140,
+            InetProtocol::WESP => 141,
+            InetProtocol::ROHC => 142,
+            InetProtocol::EXPERIMENTAL_AND_TESTING_0 => 253,
+            InetProtocol::EXPERIMENTAL_AND_TESTING_1 => 254,
+            InetProtocol::Other(x) => x,
+        }
+    }
+}

--- a/netp/src/network/ipv4.rs
+++ b/netp/src/network/ipv4.rs
@@ -220,6 +220,24 @@ impl<P: AsRef<[u8]>> IPv4<P> {
     pub fn size(&self) -> IPv4Size {
         self.size
     }
+
+    pub fn size_usize(&self) -> usize {
+        use IPv4Size::*;
+
+        match self.size {
+            S20 => 20,
+            S24 => 24,
+            S28 => 28,
+            S32 => 32,
+            S36 => 36,
+            S40 => 40,
+            S44 => 44,
+            S48 => 48,
+            S52 => 52,
+            S56 => 56,
+            S60 => 60,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]

--- a/netp/src/network/ipv4.rs
+++ b/netp/src/network/ipv4.rs
@@ -1,0 +1,266 @@
+use super::ipnum::InetProtocol;
+
+pub struct IPv4<P = ()> {
+    slice: P,
+    size: IPv4Size,
+}
+
+impl<'pkt> IPv4<&'pkt [u8]> {
+    pub fn new(slice: &'pkt [u8]) -> Result<(Self, &'pkt [u8]), Error> {
+        if slice.len() < IPv4::MIN_LEN {
+            return Err(Error::InvalidSize(slice.len()));
+        }
+
+        let size = IPv4Size::try_from_ihl_u8(slice[0] & 0xF).map_err(Error::InvalidIhl)?;
+
+        if slice[0] >> 4 != 4 {
+            return Err(Error::InvalidVersion(slice[0] >> 4));
+        }
+
+        if slice.len() < size as usize {
+            return Err(Error::InvalidSizeForIhl(slice.len(), size));
+        }
+
+        let (slice, rem) = slice.split_at(size as usize);
+        Ok((Self { slice, size }, rem))
+    }
+}
+
+impl<'pkt> IPv4<&'pkt mut [u8]> {
+    pub fn new_mut(slice: &'pkt mut [u8]) -> Result<(Self, &'pkt mut [u8]), Error> {
+        if slice.len() < IPv4::MIN_LEN {
+            return Err(Error::InvalidSize(slice.len()));
+        }
+
+        let size = IPv4Size::try_from_ihl_u8(slice[0] & 0xF).map_err(Error::InvalidIhl)?;
+
+        if slice[0] >> 4 != 4 {
+            return Err(Error::InvalidVersion(slice[0] >> 4));
+        }
+
+        if slice.len() < size as usize {
+            return Err(Error::InvalidSizeForIhl(slice.len(), size));
+        }
+
+        let (slice, rem) = slice.split_at_mut(size as usize);
+        Ok((Self { slice, size }, rem))
+    }
+}
+
+#[derive(Debug)]
+pub enum IhlError {
+    InvalidIhl(u8),
+}
+
+pub enum Error {
+    InvalidIhl(IhlError),
+    InvalidSize(usize),
+    InvalidSizeForIhl(usize, IPv4Size),
+    InvalidVersion(u8),
+}
+
+impl<P: AsMut<[u8]> + AsRef<[u8]>> IPv4<P> {
+    pub fn set_csum(&mut self, csum: u16) {
+        self.slice.as_mut()[10..12].copy_from_slice(&csum.to_be_bytes());
+    }
+
+    pub fn update_csum(&mut self) {
+        self.set_csum(self.calc_csum())
+    }
+
+    pub fn slice_mut(&mut self) -> &mut [u8] {
+        self.slice.as_mut()
+    }
+
+    pub fn set_source(&mut self, source: &[u8; 4]) {
+        self.slice.as_mut()[12..16].copy_from_slice(source)
+    }
+
+    pub fn set_source_u32(&mut self, source: u32) {
+        self.slice.as_mut()[12..16].copy_from_slice(&source.to_be_bytes())
+    }
+
+    pub fn set_destination_u32(&mut self, destination: u32) {
+        self.slice.as_mut()[16..20].copy_from_slice(&destination.to_be_bytes())
+    }
+
+    pub fn set_destination(&mut self, destination: &[u8; 4]) {
+        self.slice.as_mut()[16..20].copy_from_slice(destination)
+    }
+
+    pub fn set_total_length(&mut self, value: &[u8; 2]) {
+        self.slice.as_mut()[2..4].copy_from_slice(value)
+    }
+
+    pub fn set_total_length_u16(&mut self, value: u16) {
+        self.slice.as_mut()[2..4].copy_from_slice(&value.to_be_bytes())
+    }
+
+    pub fn set_protocol(&mut self, protocol: InetProtocol) {
+        self.slice.as_mut()[9] = u8::from(protocol);
+    }
+}
+
+impl IPv4<()> {
+    pub const MIN_LEN: usize = 20;
+    pub const MAX_LEN: usize = 60;
+}
+
+impl<P: AsRef<[u8]>> IPv4<P> {
+    pub fn csum(&self) -> u16 {
+        u16::from_be_bytes(*self.slice.as_ref()[10..12].first_chunk::<2>().unwrap())
+    }
+
+    pub fn calc_csum(&self) -> u16 {
+        etherparse::checksum::Sum16BitWords::new()
+            .add_2bytes([(4 << 4) | self.ihl_u8(), (self.dscp() << 2) | self.ecn()])
+            .add_2bytes(self.total_length().to_be_bytes())
+            .add_2bytes(self.identification().to_be_bytes())
+            .add_2bytes({
+                let frag_off_be = self.fragment_offset();
+                let flags = {
+                    let mut result = 0;
+                    if self.dont_fragment() {
+                        result |= 64;
+                    }
+                    if self.more_fragments() {
+                        result |= 32;
+                    }
+                    result
+                };
+                [flags | (frag_off_be[0] & 0x1f), frag_off_be[1]]
+            })
+            .add_2bytes([self.ttl(), self.protocol_u8()])
+            .add_4bytes(*self.source())
+            .add_4bytes(*self.destination())
+            .add_slice(self.options())
+            .ones_complement()
+            .to_be()
+    }
+
+    pub fn slice(&self) -> &[u8] {
+        &self.slice.as_ref()
+    }
+
+    pub fn version(&self) -> u8 {
+        self.slice.as_ref()[0] >> 4
+    }
+
+    pub fn source(&self) -> &[u8; 4] {
+        self.slice.as_ref()[12..16].first_chunk::<4>().unwrap()
+    }
+
+    pub fn source_u32(&self) -> u32 {
+        u32::from_be_bytes(*self.slice.as_ref()[12..16].first_chunk::<4>().unwrap())
+    }
+
+    pub fn destination_u32(&self) -> u32 {
+        u32::from_be_bytes(*self.slice.as_ref()[16..20].first_chunk::<4>().unwrap())
+    }
+
+    pub fn destination(&self) -> &[u8; 4] {
+        self.slice.as_ref()[16..20].first_chunk::<4>().unwrap()
+    }
+
+    pub fn ttl(&self) -> u8 {
+        self.slice.as_ref()[8]
+    }
+
+    pub fn options(&self) -> &[u8] {
+        &self.slice.as_ref()[IPv4::MIN_LEN..self.size as usize]
+    }
+
+    pub fn dscp(&self) -> u8 {
+        self.slice.as_ref()[1] >> 2
+    }
+
+    pub fn ecn(&self) -> u8 {
+        self.slice.as_ref()[1] & 0b11
+    }
+
+    pub fn total_length(&self) -> u16 {
+        u16::from_be_bytes(*self.slice.as_ref()[2..4].first_chunk::<2>().unwrap())
+    }
+
+    pub fn identification(&self) -> u16 {
+        u16::from_be_bytes(*self.slice.as_ref()[4..6].first_chunk::<2>().unwrap())
+    }
+
+    pub fn total_length_u16(&self) -> u16 {
+        u16::from_be_bytes(*self.slice.as_ref()[2..4].first_chunk::<2>().unwrap())
+    }
+
+    pub fn fragment_offset(&self) -> [u8; 2] {
+        let mut res = [0, 0];
+        res[0] = self.slice.as_ref()[6] & 0b11111;
+        res[1] = self.slice.as_ref()[7];
+        res
+    }
+
+    pub fn dont_fragment(&self) -> bool {
+        (self.slice.as_ref()[6] >> 6) & 0b01 == 1
+    }
+
+    pub fn more_fragments(&self) -> bool {
+        (self.slice.as_ref()[6] >> 5) & 0b001 == 1
+    }
+
+    pub fn protocol(&self) -> InetProtocol {
+        InetProtocol::from(self.slice.as_ref()[9])
+    }
+
+    pub fn protocol_u8(&self) -> u8 {
+        self.slice.as_ref()[9]
+    }
+
+    pub fn ihl_u8(&self) -> u8 {
+        self.slice.as_ref()[0] & 0xF
+    }
+
+    pub fn size(&self) -> IPv4Size {
+        self.size
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[repr(usize)]
+pub enum IPv4Size {
+    S20 = 20,
+    S24 = 24,
+    S28 = 28,
+    S32 = 32,
+    S36 = 36,
+    S40 = 40,
+    S44 = 44,
+    S48 = 48,
+    S52 = 52,
+    S56 = 56,
+    S60 = 60,
+}
+
+impl From<IhlError> for Error {
+    fn from(value: IhlError) -> Self {
+        Error::InvalidIhl(value)
+    }
+}
+
+impl IPv4Size {
+    pub fn try_from_ihl_u8(ihl: u8) -> Result<Self, IhlError> {
+        Ok(match ihl {
+            5 => IPv4Size::S20,
+            6 => IPv4Size::S24,
+            7 => IPv4Size::S28,
+            8 => IPv4Size::S32,
+            9 => IPv4Size::S36,
+            10 => IPv4Size::S40,
+            11 => IPv4Size::S44,
+            12 => IPv4Size::S48,
+            13 => IPv4Size::S52,
+            14 => IPv4Size::S56,
+            15 => IPv4Size::S60,
+            x => {
+                return Err(IhlError::InvalidIhl(x));
+            }
+        })
+    }
+}

--- a/netp/src/network/mod.rs
+++ b/netp/src/network/mod.rs
@@ -1,0 +1,5 @@
+pub use ipnum::*;
+pub use ipv4::*;
+
+pub mod ipv4;
+pub mod ipnum;

--- a/netp/src/transport/mod.rs
+++ b/netp/src/transport/mod.rs
@@ -1,0 +1,2 @@
+pub mod tcp;
+pub mod udp;

--- a/netp/src/transport/tcp.rs
+++ b/netp/src/transport/tcp.rs
@@ -1,0 +1,160 @@
+pub struct Tcp<'pkt> {
+    slice: &'pkt [u8],
+    size: TcpSize,
+}
+
+pub enum Error {
+    InvalidSize(usize),
+    InvalidSizeForOffset(usize, TcpSize),
+    InvalidDataOffset(DataOffsetError),
+}
+
+impl<'pkt> Tcp<'pkt> {
+    pub const MIN_LEN: usize = 20;
+    pub const MAX_LEN: usize = 60;
+
+    pub fn new(slice: &'pkt [u8]) -> Result<(Self, &'pkt [u8]), Error> {
+        if slice.len() < Self::MIN_LEN {
+            return Err(Error::InvalidSize(slice.len()));
+        }
+
+        let size =
+            TcpSize::try_from_data_offset_u8(slice[12] >> 4).map_err(Error::InvalidDataOffset)?;
+
+        if slice.len() < size as usize {
+            return Err(Error::InvalidSizeForOffset(slice.len(), size));
+        }
+
+        let (slice, rem) = slice.split_at(size as usize);
+
+        Ok((Self { slice, size }, rem))
+    }
+}
+
+impl Tcp<'_> {
+    pub fn size(&self) -> TcpSize {
+        self.size
+    }
+
+    pub fn destination(&self) -> u16 {
+        u16::from_be_bytes(*self.slice[2..4].first_chunk::<2>().unwrap())
+    }
+
+    pub fn source(&self) -> u16 {
+        u16::from_be_bytes(*self.slice[0..2].first_chunk::<2>().unwrap())
+    }
+
+    pub fn window_size(&self) -> u16 {
+        u16::from_be_bytes(*self.slice[14..16].first_chunk::<2>().unwrap())
+    }
+
+    pub fn slice(&self) -> &[u8] {
+        self.slice
+    }
+
+    pub fn csum(&self) -> u16 {
+        u16::from_be_bytes(*self.slice[16..18].first_chunk::<2>().unwrap())
+    }
+
+    pub fn urgent_pointer(&self) -> u16 {
+        u16::from_be_bytes(*self.slice[18..20].first_chunk::<2>().unwrap())
+    }
+
+    pub fn sequence_num(&self) -> u32 {
+        u32::from_be_bytes(*self.slice[4..8].first_chunk::<4>().unwrap())
+    }
+
+    pub fn ack_num(&self) -> u32 {
+        u32::from_be_bytes(*self.slice[8..12].first_chunk::<4>().unwrap())
+    }
+
+    pub fn data_offset(&self) -> u8 {
+        self.slice[12] >> 4
+    }
+
+    pub fn flags(&self) -> u8 {
+        self.slice[13]
+    }
+
+    pub fn options(&self) -> &[u8] {
+        &self.slice[Self::MIN_LEN..self.size as usize]
+    }
+
+    pub fn cwr(&self) -> bool {
+        self.slice[13] >> 7 == 1
+    }
+
+    pub fn ece(&self) -> bool {
+        (self.slice[13] >> 6) & 1 == 1
+    }
+
+    pub fn urg(&self) -> bool {
+        (self.slice[13] >> 5) & 1 == 1
+    }
+
+    pub fn ack(&self) -> bool {
+        (self.slice[13] >> 4) & 1 == 1
+    }
+
+    pub fn psh(&self) -> bool {
+        (self.slice[13] >> 3) & 1 == 1
+    }
+
+    pub fn rst(&self) -> bool {
+        (self.slice[13] >> 2) & 1 == 1
+    }
+
+    pub fn syn(&self) -> bool {
+        (self.slice[13] >> 1) & 1 == 1
+    }
+
+    pub fn fin(&self) -> bool {
+        self.slice[13] & 1 == 1
+    }
+
+    pub fn ns(&self) -> bool {
+        self.slice[12] & 1 == 1
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[repr(usize)]
+pub enum TcpSize {
+    S20 = 20,
+    S24 = 24,
+    S28 = 28,
+    S32 = 32,
+    S36 = 36,
+    S40 = 40,
+    S44 = 44,
+    S48 = 48,
+    S52 = 52,
+    S56 = 56,
+    S60 = 60,
+}
+
+impl TcpSize {
+    pub fn try_from_data_offset_u8(ihl: u8) -> Result<Self, DataOffsetError> {
+        Ok(match ihl {
+            5 => TcpSize::S20,
+            6 => TcpSize::S24,
+            7 => TcpSize::S28,
+            8 => TcpSize::S32,
+            9 => TcpSize::S36,
+            10 => TcpSize::S40,
+            11 => TcpSize::S44,
+            12 => TcpSize::S48,
+            13 => TcpSize::S52,
+            14 => TcpSize::S56,
+            15 => TcpSize::S60,
+            x => {
+                return Err(DataOffsetError::InvalidOffset(x));
+            }
+        })
+    }
+}
+
+#[derive(Debug)]
+pub enum DataOffsetError {
+    InvalidOffset(u8),
+}

--- a/netp/src/transport/tcp.rs
+++ b/netp/src/transport/tcp.rs
@@ -57,6 +57,24 @@ impl<'pkt> Tcp<&'pkt [u8]> {
         self.size
     }
 
+    pub fn size_usize(&self) -> usize {
+        use TcpSize::*;
+
+        match self.size {
+            S20 => 20,
+            S24 => 24,
+            S28 => 28,
+            S32 => 32,
+            S36 => 36,
+            S40 => 40,
+            S44 => 44,
+            S48 => 48,
+            S52 => 52,
+            S56 => 56,
+            S60 => 60,
+        }
+    }
+
     pub fn destination(&self) -> u16 {
         u16::from_be_bytes(*self.slice[2..4].first_chunk::<2>().unwrap())
     }

--- a/netp/src/transport/udp.rs
+++ b/netp/src/transport/udp.rs
@@ -1,0 +1,58 @@
+pub struct Udp<'pkt> {
+    slice: &'pkt mut [u8],
+}
+
+pub enum Error {
+    InvalidLength(usize),
+}
+
+impl<'pkt> Udp<'pkt> {
+    pub const SIZE: usize = 8;
+    pub fn new(slice: &'pkt mut [u8]) -> Result<(Self, &'pkt mut [u8]), Error> {
+        if slice.len() < Self::SIZE {
+            return Err(Error::InvalidLength(slice.len()));
+        }
+
+        let (slice, rem) = slice.split_at_mut(Self::SIZE);
+
+        Ok((Self { slice }, rem))
+    }
+}
+
+impl Udp<'_> {
+    pub fn source(&self) -> u16 {
+        u16::from_be_bytes(*self.slice[0..2].first_chunk::<2>().unwrap())
+    }
+
+    pub fn destination(&self) -> u16 {
+        u16::from_be_bytes(*self.slice[2..4].first_chunk::<2>().unwrap())
+    }
+
+    pub fn length(&self) -> u16 {
+        u16::from_be_bytes(*self.slice[4..6].first_chunk::<2>().unwrap())
+    }
+
+    pub fn checksum(&self) -> &[u8; 2] {
+        self.slice[6..8].first_chunk::<2>().unwrap()
+    }
+
+    pub fn set_source(&mut self, source: u16) {
+        self.slice[0..2].copy_from_slice(&source.to_be_bytes())
+    }
+
+    pub fn set_destination(&mut self, destination: u16) {
+        self.slice[2..4].copy_from_slice(&destination.to_be_bytes())
+    }
+
+    pub fn set_length(&mut self, length: u16) {
+        self.slice[4..6].copy_from_slice(&length.to_be_bytes())
+    }
+
+    pub fn set_checksum(&mut self, checksum: u16) {
+        self.slice[6..8].copy_from_slice(&checksum.to_be_bytes())
+    }
+
+    pub fn set_checksum_zero(&mut self) {
+        self.set_checksum(0);
+    }
+}


### PR DESCRIPTION
- Adds netp as a member of the Cargo Workspace
- Implements a program array that allows parsing specialization
- Implements `ipv4_tcp` for parsing and enforcing rules.

To consider:

- Rule array per OSI level. For example `LINK_RULES`, `TRANSPORT_RULES`, `NET_RULES`. This would allow us to scan less rules per layer and delay scanning rules for bigger rules up in the call-chain