### PR TITLE
Event querying

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,6 +778,7 @@ version = "0.1.0"
 dependencies = [
  "aya",
  "aya-ebpf",
+ "chrono",
  "netp",
  "schemars",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,6 +1298,7 @@ name = "message"
 version = "0.1.0"
 dependencies = [
  "async-bincode",
+ "chrono",
  "firewall-common",
  "schemars",
  "serde",
@@ -1800,6 +1801,7 @@ version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "schemars_derive",
  "serde",

--- a/firewall-common/Cargo.toml
+++ b/firewall-common/Cargo.toml
@@ -8,7 +8,7 @@ default = []
 serde = ["dep:serde", "netp/serde"]
 aya = ["dep:aya"]
 bpf = ["dep:aya-ebpf"]
-schema = ["serde", "dep:schemars", "netp/schema"]
+schema = ["serde", "dep:schemars", "netp/schema", "schemars/chrono"]
 chrono = ["dep:chrono"]
 
 [dependencies]

--- a/firewall-common/Cargo.toml
+++ b/firewall-common/Cargo.toml
@@ -9,6 +9,7 @@ serde = ["dep:serde", "netp/serde"]
 aya = ["dep:aya"]
 bpf = ["dep:aya-ebpf"]
 schema = ["serde", "dep:schemars", "netp/schema"]
+chrono = ["dep:chrono"]
 
 [dependencies]
 aya = { version = "0.13", optional = true }
@@ -16,6 +17,7 @@ aya-ebpf = { version = "0.1.0", optional = true }
 netp.path = "../netp"
 serde = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
+chrono = { workspace = true, optional = true }
 
 [lib]
 path = "src/lib.rs"

--- a/firewall-common/src/lib.rs
+++ b/firewall-common/src/lib.rs
@@ -82,6 +82,16 @@ pub struct StoredRuleDecoded {
     pub rule: Rule,
 }
 
+#[cfg(feature = "serde")]
+#[cfg(feature = "chrono")]
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct StoredEventDecoded {
+    pub time: chrono::NaiveDateTime,
+    pub event: Event,
+}
+
 #[cfg(feature = "aya")]
 unsafe impl aya::Pod for Rule {}
 

--- a/firewall/src/main.rs
+++ b/firewall/src/main.rs
@@ -564,6 +564,13 @@ async fn handle_message(
                                 .load::<StoredEvent>(&mut db)
                                 .await
                         }
+                        message::EventQuery::Since(datetime) => {
+                            events::table
+                                .filter(events::time.ge(datetime))
+                                .select(StoredEvent::as_select())
+                                .load::<StoredEvent>(&mut db)
+                                .await
+                        }
                     }
                     .unwrap();
 

--- a/firewall/src/main.rs
+++ b/firewall/src/main.rs
@@ -638,19 +638,19 @@ async fn handle_event(
     let mut buffer = [0u8; std::mem::size_of::<Event>()];
 
     while let Some(item) = ring_buf.next() {
-        let (_, [item], _) = (unsafe { item.align_to::<Event>() }) else {
+        let (_, [event], _) = (unsafe { item.align_to::<Event>() }) else {
             continue;
         };
 
-        if let Event::Pass = item {
+        if let Event::Pass = event {
             continue;
         }
 
-        etx.send(*item).ok(); // We dont care if there are no event listeners
+        etx.send(*event).ok(); // We dont care if there are no event listeners
 
-        info!("{:?}", item);
+        info!("{:?}", event);
 
-        bincode::serialize_into(&mut buffer[..], item).unwrap();
+        bincode::serialize_into(&mut buffer[..], event).unwrap();
         diesel::insert_into(events::table)
             .values(StoredEvent {
                 time: chrono::Local::now().naive_utc(),

--- a/message/Cargo.toml
+++ b/message/Cargo.toml
@@ -9,6 +9,7 @@ serde.workspace = true
 firewall-common = { path = "../firewall-common", features = ["serde", "chrono"] }
 schemars = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
+chrono.workspace = true
 
 [features]
 schema = ["dep:schemars", "firewall-common/schema", "dep:serde_json"]

--- a/message/Cargo.toml
+++ b/message/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 async-bincode.workspace = true
 serde.workspace = true
-firewall-common = { path = "../firewall-common", features = ["serde"] }
+firewall-common = { path = "../firewall-common", features = ["serde", "chrono"] }
 schemars = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 

--- a/message/src/firewall.rs
+++ b/message/src/firewall.rs
@@ -1,0 +1,55 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum Response {
+    Id(u32),
+    ListFull,
+    Rules(Vec<firewall_common::StoredRuleDecoded>),
+    Rule(firewall_common::StoredRuleDecoded),
+    DoesNotExist,
+    Status(Status),
+    RuleChange(RuleChange),
+    Events(Vec<firewall_common::StoredEventDecoded>),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum RuleChange {
+    NoSuchRule,
+    NoChangeRequired(RuleStatus),
+    Change(RuleStatus),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum RuleStatus {
+    Active,
+    Inactive,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum Status {
+    Stopped,
+    Running,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum Request {
+    AddRule(firewall_common::StoredRuleDecoded),
+    DeleteRule(u32),
+    EnableRule(u32),
+    DisableRule(u32),
+    ToggleRule(u32),
+    GetRule(u32),
+    GetRules,
+    Status,
+    GetEvents(crate::EventQuery),
+}

--- a/message/src/lib.rs
+++ b/message/src/lib.rs
@@ -21,19 +21,41 @@ pub enum Message {
 pub enum EventQuery {
     All,
     Last(std::time::Duration),
+    Since(chrono::NaiveDateTime),
 }
 
 #[cfg(test)]
 #[cfg(feature = "schema")]
 mod test {
+
     use super::*;
     use firewall_common::*;
 
     #[test]
     pub fn print_schamas() {
         use schemars::{schema_for, JsonSchema};
+        use std::time::Duration;
 
-        let schema = schema_for!(Rule);
+        let schema = schema_for!(EventQuery);
         println!("{}", serde_json::to_string_pretty(&schema).unwrap());
+
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&EventQuery::All).unwrap()
+        );
+
+        let duration = Duration::from_secs(320);
+
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&EventQuery::Last(duration)).unwrap()
+        );
+
+        let since = chrono::Local::now().naive_utc() - Duration::from_secs(60 * 60 * 24 * 30);
+
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&EventQuery::Since(since)).unwrap()
+        );
     }
 }

--- a/message/src/lib.rs
+++ b/message/src/lib.rs
@@ -3,6 +3,8 @@ pub use firewall_common;
 
 use serde::{Deserialize, Serialize};
 
+pub mod firewall;
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -13,60 +15,12 @@ pub enum Message {
     Firewall(firewall::Request),
 }
 
-pub mod firewall {
-
-    use serde::{Deserialize, Serialize};
-    #[derive(Debug, Serialize, Deserialize)]
-    #[serde(rename_all = "snake_case")]
-    #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-    pub enum Response {
-        Id(u32),
-        ListFull,
-        Rules(Vec<firewall_common::StoredRuleDecoded>),
-        Rule(firewall_common::StoredRuleDecoded),
-        DoesNotExist,
-        Status(Status),
-        RuleChange(RuleChange),
-    }
-
-    #[derive(Debug, Serialize, Deserialize)]
-    #[serde(rename_all = "snake_case")]
-    #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-    pub enum RuleChange {
-        NoSuchRule,
-        NoChangeRequired(RuleStatus),
-        Change(RuleStatus),
-    }
-
-    #[derive(Debug, Serialize, Deserialize)]
-    #[serde(rename_all = "snake_case")]
-    #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-    pub enum RuleStatus {
-        Active,
-        Inactive,
-    }
-
-    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-    #[serde(rename_all = "snake_case")]
-    #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-    pub enum Status {
-        Stopped,
-        Running,
-    }
-
-    #[derive(Debug, Serialize, Deserialize)]
-    #[serde(rename_all = "snake_case")]
-    #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-    pub enum Request {
-        AddRule(firewall_common::StoredRuleDecoded),
-        DeleteRule(u32),
-        EnableRule(u32),
-        DisableRule(u32),
-        ToggleRule(u32),
-        GetRule(u32),
-        GetRules,
-        Status,
-    }
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum EventQuery {
+    All,
+    Last(std::time::Duration),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- [x] Query all events (done in 5c62f1f252b5c80e3115b8620ea217e3907f937e)

```fish
curl -X GET http://localhost:9988/firewall/events/query\
              -H "Content-Type: application/json"\
              -d '"all"'
```

- [x] Query since time (duration)

```fish
curl -X GET http://localhost:9988/firewall/events/query\
              -H "Content-Type: application/json"\
              -d '{ "last": { "secs": 320, "nanos": 0 } }'
```

- [x] Query since time (timestamp)

```fish
curl -X GET http://localhost:9988/firewall/events/query\
              -H "Content-Type: application/json"\
              -d '{ "since": "2024-11-04T13:53:20.104238832"  }'
```