### PR TITLE
New `message::Log`; `front`: WebSocket listener

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,7 @@ name = "controller"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "chrono",
  "deadpool",
  "front-components",
  "futures",

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -13,6 +13,7 @@ serde.workspace = true
 deadpool.workspace = true
 futures.workspace = true
 maud.workspace = true
+chrono.workspace = true
 
 message.path = "../message"
 front-components.path = "../front-components"

--- a/controller/src/firewall/mod.rs
+++ b/controller/src/firewall/mod.rs
@@ -8,8 +8,8 @@ use futures::{SinkExt, StreamExt};
 use maud::Markup;
 use message::{
     async_bincode::{tokio::AsyncBincodeStream, AsyncDestination},
-    firewall::{self, Status},
-    firewall_common::{Event, StoredEventDecoded, StoredRuleDecoded},
+    firewall::{self, Log, Status},
+    firewall_common::{StoredEventDecoded, StoredRuleDecoded},
     EventQuery, Message,
 };
 use tokio::net::UnixStream;
@@ -102,10 +102,10 @@ pub async fn event_dispatcher(mut socket: WebSocket) {
     let uds = UnixStream::connect("/run/adam/firewall_events")
         .await
         .unwrap();
-    let mut uds: AsyncBincodeReader<UnixStream, Event> = AsyncBincodeReader::from(uds);
+    let mut uds: AsyncBincodeReader<UnixStream, Log> = AsyncBincodeReader::from(uds);
 
     loop {
-        let Ok(event): Result<Event, _> = futures::StreamExt::next(&mut uds).await.unwrap() else {
+        let Ok(event): Result<Log, _> = futures::StreamExt::next(&mut uds).await.unwrap() else {
             break; // If it fails it may be that the firewall stopped
         };
 

--- a/controller/src/htmx.rs
+++ b/controller/src/htmx.rs
@@ -6,6 +6,7 @@ pub enum Htmx {
     Disabled,
 }
 
+#[allow(dead_code)]
 impl Htmx {
     #[inline(always)]
     pub fn enabled(&self) -> bool {

--- a/firewall-common/src/lib.rs
+++ b/firewall-common/src/lib.rs
@@ -84,7 +84,7 @@ pub struct StoredRuleDecoded {
 
 #[cfg(feature = "serde")]
 #[cfg(feature = "chrono")]
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct StoredEventDecoded {

--- a/firewall/src/main.rs
+++ b/firewall/src/main.rs
@@ -218,7 +218,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 select! {
                     Ok((s, _addr)) = listener.accept() => {
                         tokio::task::spawn({
-                            let erx: broadcast::Receiver<Event> = etx.subscribe();
+                            let erx: broadcast::Receiver<Log> = etx.subscribe();
                             let rx = rx.clone();
                             emit_to_suscriber(rx,erx, s)
                         });
@@ -331,12 +331,12 @@ async fn main() -> Result<(), anyhow::Error> {
 
 async fn emit_to_suscriber(
     mut rx: Receiver<State>,
-    mut erx: broadcast::Receiver<Event>,
+    mut erx: broadcast::Receiver<Log>,
     s: UnixStream,
 ) {
     use message::async_bincode::tokio::AsyncBincodeWriter;
 
-    let mut s: AsyncBincodeWriter<UnixStream, Event, message::async_bincode::AsyncDestination> =
+    let mut s: AsyncBincodeWriter<UnixStream, Log, message::async_bincode::AsyncDestination> =
         AsyncBincodeWriter::from(s).for_async();
     loop {
         select! {
@@ -687,7 +687,7 @@ async fn handle_stream(
 
 async fn handle_event(
     guard: Result<AsyncFdReadyMutGuard<'_, RingBuf<MapData>>, Error>,
-    etx: &mut broadcast::Sender<Event>,
+    etx: &mut broadcast::Sender<Log>,
 ) {
     let mut guard = guard.unwrap();
     let ring_buf = guard.get_inner_mut();
@@ -703,14 +703,20 @@ async fn handle_event(
             continue;
         }
 
-        etx.send(*event).ok(); // We dont care if there are no event listeners
+        let time = chrono::Local::now().naive_utc();
+        let stored = StoredEventDecoded {
+            time,
+            event: *event,
+        };
+
+        etx.send(Log::Event(stored)).ok(); // We dont care if there are no event listeners
 
         info!("{:?}", event);
 
         bincode::serialize_into(&mut buffer[..], event).unwrap();
         diesel::insert_into(events::table)
             .values(StoredEventRef {
-                time: chrono::Local::now().naive_utc(),
+                time,
                 event: &buffer,
             })
             .execute(&mut db)

--- a/firewall/src/main.rs
+++ b/firewall/src/main.rs
@@ -218,7 +218,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 select! {
                     Ok((s, _addr)) = listener.accept() => {
                         tokio::task::spawn({
-                            let erx: broadcast::Receiver<Log> = etx.subscribe();
+                            let erx: broadcast::Receiver<LogKind> = etx.subscribe();
                             let rx = rx.clone();
                             emit_to_suscriber(rx,erx, s)
                         });
@@ -331,12 +331,12 @@ async fn main() -> Result<(), anyhow::Error> {
 
 async fn emit_to_suscriber(
     mut rx: Receiver<State>,
-    mut erx: broadcast::Receiver<Log>,
+    mut erx: broadcast::Receiver<LogKind>,
     s: UnixStream,
 ) {
     use message::async_bincode::tokio::AsyncBincodeWriter;
 
-    let mut s: AsyncBincodeWriter<UnixStream, Log, message::async_bincode::AsyncDestination> =
+    let mut s: AsyncBincodeWriter<UnixStream, LogKind, message::async_bincode::AsyncDestination> =
         AsyncBincodeWriter::from(s).for_async();
     loop {
         select! {
@@ -687,7 +687,7 @@ async fn handle_stream(
 
 async fn handle_event(
     guard: Result<AsyncFdReadyMutGuard<'_, RingBuf<MapData>>, Error>,
-    etx: &mut broadcast::Sender<Log>,
+    etx: &mut broadcast::Sender<LogKind>,
 ) {
     let mut guard = guard.unwrap();
     let ring_buf = guard.get_inner_mut();
@@ -709,7 +709,7 @@ async fn handle_event(
             event: *event,
         };
 
-        etx.send(Log::Event(stored)).ok(); // We dont care if there are no event listeners
+        etx.send(LogKind::Event(stored)).ok(); // We dont care if there are no event listeners
 
         info!("{:?}", event);
 

--- a/front/src/main.rs
+++ b/front/src/main.rs
@@ -15,11 +15,24 @@ async fn main() {
 
     let router = Router::new()
         .route("/", get(home))
-        .nest("/firewall", firewall_router);
+        .nest("/firewall", firewall_router)
+        .fallback(not_found);
 
     let listener = TcpListener::bind("[::]:8880").await.unwrap();
 
     axum::serve(listener, router).await.unwrap();
+}
+
+async fn not_found(templ: Template) -> Markup {
+    templ.render(html! {
+        div .flex .items-center .mt-20 .justify-center {
+            div .text-center {
+                h1 .text-6xl .font-bold .text-gray-800 { "404" }
+                p .text-2xl .text-gray-600 { "Page Not Found" }
+                p .mt-4 .text-gray-500 { "Sorry, the page you are looking for does not exist." }
+            }
+        }
+    })
 }
 
 async fn firewall_events(templ: Template) -> Markup {

--- a/front/src/template.rs
+++ b/front/src/template.rs
@@ -15,6 +15,7 @@ pub struct Template {
     mode: ContentMode,
 }
 
+#[allow(dead_code)]
 impl Template {
     #[must_use]
     pub fn mode(&self) -> ContentMode {

--- a/front/src/template.rs
+++ b/front/src/template.rs
@@ -98,9 +98,10 @@ fn Template(title: &str, mode: ContentMode, content: Markup) -> Markup {
                 meta charset="utf-8";
                 meta name="viewport" content="width=device-width, initial-scale=1";
                 script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" {}
-                script src="https://unpkg.com/htmx.org@1.9.9" {}
+                script src="https://unpkg.com/htmx.org" {}
                 script src="https://unpkg.com/htmx.org/dist/ext/response-targets.js" {}
                 script src="https://unpkg.com/htmx.org/dist/ext/head-support.js" {}
+                script src="https://unpkg.com/htmx.org/dist/ext/ws.js" {}
                 script src="https://cdn.tailwindcss.com" {}
                 script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer {}
                 script {

--- a/message/src/firewall.rs
+++ b/message/src/firewall.rs
@@ -1,3 +1,4 @@
+use firewall_common::StoredEventDecoded;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -12,6 +13,13 @@ pub enum Response {
     Status(Status),
     RuleChange(RuleChange),
     Events(Vec<firewall_common::StoredEventDecoded>),
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum Log {
+    Event(StoredEventDecoded),
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/message/src/firewall.rs
+++ b/message/src/firewall.rs
@@ -18,7 +18,7 @@ pub enum Response {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub enum Log {
+pub enum LogKind {
     Event(StoredEventDecoded),
 }
 

--- a/message/src/lib.rs
+++ b/message/src/lib.rs
@@ -24,6 +24,14 @@ pub enum EventQuery {
     Since(chrono::NaiveDateTime),
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct Log<K> {
+    pub time: chrono::NaiveDateTime,
+    pub kind: K,
+}
+
 #[cfg(test)]
 #[cfg(feature = "schema")]
 mod test {

--- a/netp/src/transport/tcp.rs
+++ b/netp/src/transport/tcp.rs
@@ -52,7 +52,7 @@ impl<'pkt> Tcp<&'pkt mut [u8]> {
     }
 }
 
-impl<'pkt> Tcp<&'pkt [u8]> {
+impl Tcp<&[u8]> {
     pub fn size(&self) -> TcpSize {
         self.size
     }


### PR DESCRIPTION
- [x] #26
    - [x] Basic implementation (done in b96e578a8cb3b3aec300ee74f2704ada22dee5e7)
    - [x] Make message::Log contain its timestamp (done in 5bdb47160c6a0e7cabe77ecdfc372569b41b712d)
- [x] #45 (done in b96e578a8cb3b3aec300ee74f2704ada22dee5e7)
- [x] #60 (done in 63b3cc33a61ac29a7badd7b3c0316d9963667319)
- [ ] ~#53~
- [ ] ~#58~
- [ ] ~#20~
