### PR TITLE
🚀 feat(firewall): Add IP selection and dynamic status update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -432,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",
@@ -472,6 +472,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "chrono",
+ "clap",
  "deadpool",
  "front-components",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,6 +832,7 @@ dependencies = [
  "message",
  "rand",
  "reqwest",
+ "serde",
  "serde_json",
  "strum",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,7 @@ checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
 dependencies = [
  "async-trait",
  "axum-core",
+ "axum-macros",
  "base64",
  "bytes",
  "futures-util",
@@ -208,6 +209,17 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -17,3 +17,4 @@ chrono.workspace = true
 
 message.path = "../message"
 front-components.path = "../front-components"
+clap = { version = "4.5.21", features = ["derive"] }

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -2,7 +2,7 @@ pub use axum::{extract::State, routing::post, Router};
 use axum::{middleware::Next, response::Response};
 use deadpool::managed::Pool;
 use tokio::net::TcpListener;
-use tower_http::cors::{CorsLayer, Any};
+use tower_http::cors::{Any, CorsLayer};
 
 mod firewall;
 mod htmx;
@@ -36,11 +36,9 @@ async fn main() {
 
     let cors = CorsLayer::new()
         .allow_origin(Any)
-        .allow_methods([axum::http::Method::POST, axum::http::Method::DELETE])
-        .allow_headers([
-            axum::http::HeaderName::from_static("hx-request"),
-            axum::http::HeaderName::from_static("hx-current-url"),
-        ]);
+        .allow_methods(Any)
+        .allow_headers(Any)
+        .allow_private_network(true);
 
     let router = Router::new()
         .nest("/firewall", firewall::router())

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -1,5 +1,11 @@
+use std::{
+    net::{IpAddr, SocketAddr},
+    str::FromStr,
+};
+
 pub use axum::{extract::State, routing::post, Router};
 use axum::{middleware::Next, response::Response};
+use clap::Parser;
 use deadpool::managed::Pool;
 use tokio::net::TcpListener;
 use tower_http::cors::{Any, CorsLayer};
@@ -30,8 +36,23 @@ pub async fn insert_headers(req: axum::extract::Request, next: Next) -> Response
     response
 }
 
+#[derive(Debug, Parser)]
+struct Args {
+    #[clap(long, short, alias = "addr")]
+    address: Option<IpAddr>,
+    #[clap(long, short)]
+    port: Option<u16>,
+}
+
 #[tokio::main]
 async fn main() {
+    let Args { address, port } = Args::parse();
+    let address = address.unwrap_or(IpAddr::from_str("::").expect("Should not fail"));
+    let port = port.unwrap_or(9988);
+
+    let socket = SocketAddr::new(address, port);
+    println!("Binding to {socket:?}");
+
     let state = AppState::new();
 
     let cors = CorsLayer::new()
@@ -46,6 +67,6 @@ async fn main() {
         .layer(cors)
         .with_state(state);
 
-    let listener = TcpListener::bind("[::]:9988").await.unwrap();
+    let listener = TcpListener::bind(socket).await.unwrap();
     axum::serve(listener, router).await.unwrap()
 }

--- a/front-components/src/lib.rs
+++ b/front-components/src/lib.rs
@@ -16,6 +16,48 @@ pub fn Ref(title: impl maud::Render, href: &str) -> Markup {
     }
 }
 
+#[allow(non_snake_case)]
+pub fn Error(msg: &str) -> Markup {
+    html! {
+        div."w-full"."text-white"."bg-red-500" {
+            div."container"."flex"."items-center"."justify-between"."px-6"."py-4"."mx-auto" {
+                div."flex" {
+                    svg."w-6"."h-6"."fill-current" viewBox="0 0 40 40" {
+                        path d="M20 3.36667C10.8167 3.36667 3.3667 10.8167 3.3667 20C3.3667 29.1833 10.8167 36.6333 20 36.6333C29.1834 36.6333 36.6334 29.1833 36.6334 20C36.6334 10.8167 29.1834 3.36667 20 3.36667ZM19.1334 33.3333V22.9H13.3334L21.6667 6.66667V17.1H27.25L19.1334 33.3333Z" {}
+                    }
+                    p."mx-3" { (msg) }
+                }
+                button."p-1"."transition-colors"."duration-300"."transform"."rounded-md"."hover:bg-opacity-25"."hover:bg-gray-600"."focus:outline-none" {
+                    svg."w-5"."h-5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {
+                        path d="M6 18L18 6M6 6L18 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" {}
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[allow(non_snake_case)]
+pub fn Warning(msg: &str) -> Markup {
+    html! {
+        div."flex"."w-full"."max-w-sm"."overflow-hidden"."bg-white"."rounded-lg"."shadow-md"."dark:bg-gray-800" {
+            div."flex"."items-center"."justify-center"."w-12"."bg-red-500" {
+                svg."w-6"."h-6"."text-white"."fill-current" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg" {
+                    path d="M20 3.36667C10.8167 3.36667 3.3667 10.8167 3.3667 20C3.3667 29.1833 10.8167 36.6333 20 36.6333C29.1834 36.6333 36.6334 29.1833 36.6334 20C36.6334 10.8167 29.1834 3.36667 20 3.36667ZM19.1334 33.3333V22.9H13.3334L21.6667 6.66667V17.1H27.25L19.1334 33.3333Z" {}
+                }
+            }
+            div."px-4"."py-2".-"mx-3" {
+                div."mx-3" {
+                    span."font-semibold"."text-red-500"."dark:text-red-400" { "Error" }
+                    p."text-sm"."text-gray-600"."dark:text-gray-200" {
+                        (msg)
+                    }
+                }
+            }
+        }
+    }
+}
+
 pub fn rule_status(enabled: bool, id: u32) -> Markup {
     html! {
         @let color = { if enabled { "lime" } else { "rose" } };

--- a/front/Cargo.toml
+++ b/front/Cargo.toml
@@ -12,6 +12,7 @@ tokio = { version = "1.40.0", features = ["full"] }
 
 maud.workspace = true
 serde_json.workspace = true
+serde.workspace = true
 
 firewall-common = { path = "../firewall-common", features = ["serde"] }
 message.path = "../message"

--- a/front/Cargo.toml
+++ b/front/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 rand = "0.8.5"
-axum = "0.7.6"
+axum = { version = "0.7.6", features = ["macros"] }
 reqwest = "0.12.7"
 strum = { version = "0.26.3", features = ["derive"] }
 tokio = { version = "1.40.0", features = ["full"] }

--- a/front/src/main.rs
+++ b/front/src/main.rs
@@ -35,13 +35,13 @@ async fn ips_home(templ: Template, State(state): State<AppState>) -> Markup {
     let ips = ips.as_slice();
 
     templ
-        .render(html! {
+        .render(Padded(html! {
             div {
                 @for ip in ips.iter().enumerate() {
                     p { (format!("{ip:?}")) }
                 }
             }
-        })
+        }))
         .await
 }
 
@@ -78,7 +78,7 @@ async fn add_ip_home(templ: Template) -> Markup {
                 input type="text" id="address" name="address" required;
 
                 label for="port" { "Port:" }
-                input type="number" id="port" name="port" required;
+                input type="number" id="port" name="port" value="9988" required;
 
                 button type="submit" { "Add IP" }
             }

--- a/front/src/main.rs
+++ b/front/src/main.rs
@@ -1,15 +1,17 @@
-use axum::{extract::Path, routing::*, Router, State};
+use axum::{
+    extract::{Path, State},
+    response::IntoResponse,
+    routing::*,
+    Json, Router,
+};
 use front_components::Ref;
 use maud::{html, Markup, PreEscaped};
 use rand::RngCore;
+use serde::Deserialize;
+use std::{ops::Deref, sync::Arc};
 use template::Template;
 use tokio::net::TcpListener;
-
 use tokio::sync::RwLock;
-use std::sync::Arc;
-
-use axum::{Json, extract::{Path, State}};
-use serde::Deserialize;
 
 mod template;
 
@@ -20,81 +22,100 @@ struct IpInput {
 }
 
 // Endpoint to add an IP
-async fn add_ip(State(state): State<Arc<AppState>>, Json(input): Json<IpInput>) -> impl IntoResponse {
+async fn add_ip(State(state): State<AppState>, Json(input): Json<IpInput>) -> impl IntoResponse {
     let mut ips = state.registered_ips.write().await;
     ips.push(input.ip);
     "IP added".into_response()
 }
 
 // Endpoint to delete an IP
-async fn delete_ip(State(state): State<Arc<AppState>>, Path(ip): Path<String>) -> impl IntoResponse {
+async fn delete_ip(State(state): State<AppState>, Path(ip): Path<String>) -> impl IntoResponse {
     let mut ips = state.registered_ips.write().await;
     ips.retain(|x| x != &ip);
     "IP removed".into_response()
 }
 
 // Endpoint to get all IPs
-async fn get_ips(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+async fn get_ips(State(state): State<AppState>) -> impl IntoResponse {
     let ips = state.registered_ips.read().await;
     Json(&*ips).into_response()
 }
 
 // Endpoint to set the selected IP
 async fn set_selected_ip(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Json(input): Json<IpInput>,
 ) -> impl IntoResponse {
     *state.selected_ip.write().await = input.ip;
     "Selected IP updated".into_response()
 }
 
+impl Deref for AppState {
+    type Target = InnerState;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+#[derive(Debug, Clone)]
 struct AppState {
+    inner: Arc<InnerState>,
+}
+
+#[derive(Debug)]
+struct InnerState {
     registered_ips: RwLock<Vec<String>>,
     selected_ip: RwLock<String>,
 }
 
 #[tokio::main]
 async fn main() {
-    let state = Arc::new(AppState {
-        registered_ips: RwLock::new(vec![
-            "192.168.1.1".to_string(),
-            "192.168.1.2".to_string(),
-            "10.0.0.1".to_string(),
-        ]),
-        selected_ip: RwLock::new("192.168.1.1".to_string()),
-    });
+    let state = AppState {
+        inner: Arc::new(InnerState {
+            registered_ips: RwLock::new(vec![
+                "192.168.1.1".to_string(),
+                "192.168.1.2".to_string(),
+                "10.0.0.1".to_string(),
+                "127.0.0.1".to_string(),
+            ]),
+            selected_ip: RwLock::new("127.0.0.1".to_string()),
+        }),
+    };
 
     let firewall_router = Router::new()
         .route("/events", get(firewall_events))
         .route("/rules", get(rules))
         .route("/rules/:id", get(rule));
-    
-    let router = Router::new()
-        .route("/", get(home))
-        .nest("/firewall", firewall_router)
-        .nest("/api", ip_router)
-        .with_state(state)
-        .fallback(not_found);
 
     let ip_router = Router::new()
         .route("/ips", post(add_ip).get(get_ips))
         .route("/ips/selected", post(set_selected_ip))
         .route("/ips/:ip", delete(delete_ip));
-    
+
+    let router = Router::new()
+        .route("/", get(home))
+        .nest("/firewall", firewall_router)
+        .nest("/api", ip_router)
+        .fallback(not_found)
+        .with_state(state);
+
     let listener = TcpListener::bind("[::]:8880").await.unwrap();
     axum::serve(listener, router).await.unwrap();
 }
 
 async fn not_found(templ: Template) -> Markup {
-    templ.render(html! {
-        div .flex .items-center .mt-20 .justify-center {
-            div .text-center {
-                h1 .text-6xl .font-bold .text-gray-800 { "404" }
-                p .text-2xl .text-gray-600 { "Page Not Found" }
-                p .mt-4 .text-gray-500 { "Sorry, the page you are looking for does not exist." }
+    templ
+        .render(html! {
+            div .flex .items-center .mt-20 .justify-center {
+                div .text-center {
+                    h1 .text-6xl .font-bold .text-gray-800 { "404" }
+                    p .text-2xl .text-gray-600 { "Page Not Found" }
+                    p .mt-4 .text-gray-500 { "Sorry, the page you are looking for does not exist." }
+                }
             }
-        }
-    })
+        })
+        .await
 }
 
 #[allow(non_snake_case)]
@@ -120,19 +141,21 @@ fn FirewallLog() -> Markup {
 }
 
 async fn firewall_events(templ: Template) -> Markup {
-    templ.render(html! { (FirewallLog()) })
+    templ.render(html! { (FirewallLog()) }).await
 }
 
 async fn home(templ: Template) -> Markup {
-    templ.render(html! {
-        "Hi"
-    })
+    templ
+        .render(html! {
+            "Hi"
+        })
+        .await
 }
 
 async fn rule(
     templ: Template,
     Path((idx,)): Path<(u32,)>,
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
 ) -> Markup {
     let selected_ip = state.selected_ip.read().await.clone();
     let res = reqwest::get(format!("http://{selected_ip}:9988/firewall/rules/{idx}"))
@@ -142,26 +165,27 @@ async fn rule(
     let rule: firewall_common::StoredRuleDecoded =
         serde_json::from_str(&res.text().await.unwrap()).unwrap();
 
-    templ.render(html! {
-        div .space-5 .m-5 {
-            span .block .mb-5 {
-                (Ref("< Rules", "/firewall/rules"))
+    templ
+        .render(html! {
+            div .space-5 .m-5 {
+                span .block .mb-5 {
+                    (Ref("< Rules", "/firewall/rules"))
+                }
+
+                (front_components::rule_status(rule.rule.enabled, rule.id as u32))
+
+                h1 .text-xl .font-bold { "Rule " (rule.id) ": " (rule.name) }
+                p { (rule.description) }
+
+                code .bg-gray-100 .mt-5 .p-1 .block .whitespace-pre .overflow-x-scroll {
+                    (PreEscaped(serde_json::to_string_pretty(&rule.rule).unwrap()))
+                }
             }
-
-            (front_components::rule_status(rule.rule.enabled, rule.id as u32))
-
-            h1 .text-xl .font-bold { "Rule " (rule.id) ": " (rule.name) }
-            p { (rule.description) }
-
-            code .bg-gray-100 .mt-5 .p-1 .block .whitespace-pre .overflow-x-scroll {
-                (PreEscaped(serde_json::to_string_pretty(&rule.rule).unwrap()))
-            }
-        }
-    })
+        })
+        .await
 }
 
-async fn rules(templ: Template, State(state): State<Arc<AppState>>) -> Markup {
-    let ips = state.registered_ips.read().await.clone();
+async fn rules(templ: Template, State(state): State<AppState>) -> Markup {
     let selected_ip = state.selected_ip.read().await.clone();
 
     let res = reqwest::get(format!("http://{selected_ip}:9988/firewall/rules"))
@@ -175,49 +199,7 @@ async fn rules(templ: Template, State(state): State<Arc<AppState>>) -> Markup {
         div .space-5 .m-5 {
             h1 .text-xl .font-bold { "Firewall" }
 
-            form {
-                label for="ip-select" { "Select IP address: " }
-                select
-                    name="ip"
-                    id="ip-select"
-                {
-                    @for ip in &ips {
-                        @if ip == &selected_ip {
-                            option value=(ip) selected { (ip) }
-                        } @else {
-                            option value=(ip) { (ip) }
-                        }
-                    }
-                }
-            }
-
-            p {
-                "Status: "
-                span #status
-                    hx-get={"http://" (selected_ip) "/firewall/state"}
-                    hx-trigger="load, every 30s, refresh"
-                    hx-indicator="#loading-indicator"
-                {
-                    "Cargando..."
-                }
-                div #loading-indicator { "Actualizando..." }
-            }
-
-            script type="text/javascript" {
-                (PreEscaped(r#"
-                document.getElementById('ip-select').addEventListener('change', async function() {
-                    var selectedIp = this.value;
-                    await fetch('/api/ips/selected', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ ip: selectedIp })
-                    });
-                    var statusSpan = document.getElementById('status');
-                    statusSpan.setAttribute('hx-get', 'http://' + selectedIp + '/firewall/state');
-                    htmx.trigger(statusSpan, 'refresh');
-                });
-                "#))
-            }
+            p { "Status: " span hx-get={"http://" (selected_ip) ":9988/firewall/state"} hx-trigger="load, every 30s" {} }
 
             table .table-auto .text-left .border-separate {
                 thead {
@@ -240,7 +222,7 @@ async fn rules(templ: Template, State(state): State<Arc<AppState>>) -> Markup {
                                 (Ref("View", &format!("/firewall/rules/{}", rule.id)))
                                 button
                                     .text-sm
-                                    hx-delete={ "http://" (selected_ip) "/firewall/rules/" (rule.id) }
+                                    hx-delete={ "http://" (selected_ip) ":9988/firewall/rules/" (rule.id) }
                                     hx-target="closest tr"
                                 {
                                     "Delete"
@@ -251,5 +233,5 @@ async fn rules(templ: Template, State(state): State<Arc<AppState>>) -> Markup {
                 }
             }
         }
-    })
+    }).await
 }

--- a/front/src/sip.rs
+++ b/front/src/sip.rs
@@ -10,7 +10,7 @@ impl FromRequestParts<AppState> for Selected {
 
     async fn from_request_parts(_: &mut Parts, state: &AppState) -> Result<Self, Self::Rejection> {
         Ok(Selected(
-            (*state.inner.selected_ip.read().await).ok_or(Redirect::to("/ips"))?,
+            (*state.inner.selected_ip.read().await).ok_or(Redirect::to("/ips/add"))?,
         ))
     }
 }

--- a/front/src/sip.rs
+++ b/front/src/sip.rs
@@ -1,0 +1,16 @@
+use crate::AppState;
+use axum::{async_trait, extract::FromRequestParts, http::request::Parts, response::Redirect};
+use std::net::SocketAddr;
+
+pub struct Selected(pub SocketAddr);
+
+#[async_trait]
+impl FromRequestParts<AppState> for Selected {
+    type Rejection = Redirect;
+
+    async fn from_request_parts(_: &mut Parts, state: &AppState) -> Result<Self, Self::Rejection> {
+        Ok(Selected(
+            (*state.inner.selected_ip.read().await).ok_or(Redirect::to("/ips"))?,
+        ))
+    }
+}

--- a/front/src/template.rs
+++ b/front/src/template.rs
@@ -4,6 +4,9 @@ use front_components::Ref;
 use maud::{html, Markup, DOCTYPE};
 use strum::{EnumIter, IntoEnumIterator};
 
+use axum::extract::State;
+use std::sync::Arc;
+
 #[derive(Debug, Clone, Copy)]
 pub enum ContentMode {
     Full,
@@ -84,12 +87,16 @@ impl maud::Render for Section {
 #[allow(clippy::too_many_lines)]
 #[allow(clippy::needless_pass_by_value)]
 #[allow(non_snake_case)]
-fn Template(title: &str, mode: ContentMode, content: Markup) -> Markup {
+fn Template(title: &str, mode: ContentMode, content: Markup, state: Arc<AppState>) -> Markup {
     if let ContentMode::Embedded = mode {
         return html! {
             (content)
         };
     }
+
+    // Get IP list and selected IP from the global AppState
+    let registered_ips = state.registered_ips.read().await.clone();
+    let selected_ip = state.selected_ip.read().await.clone();
 
     html! {
         (DOCTYPE)
@@ -169,20 +176,47 @@ fn Template(title: &str, mode: ContentMode, content: Markup) -> Markup {
                         }
                     }
 
-                    div
-                        .flex.flex-row.items-center."space-x-4"
-                        x-data = "{ open: false }"
-                    {}
+                    // IP Selector Dropdown
+                    div.flex.flex-row.items-center."space-x-4" {
+                        form {
+                            label for="ip-select" { "Select IP: " }
+                            select
+                                name="ip"
+                                id="ip-select"
+                            {
+                                @for ip in &registered_ips {
+                                    @if ip == &selected_ip {
+                                        option value=(ip) selected { (ip) }
+                                    } @else {
+                                        option value=(ip) { (ip) }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
 
                 main #main { (content) }
 
                 (Footer())
             }
+
+            script type="text/javascript" {
+                (PreEscaped(r#"
+                document.getElementById('ip-select').addEventListener('change', async function() {
+                    const selectedIp = this.value;
+                    await fetch('/api/ips/selected', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ ip: selectedIp })
+                    });
+                    // Optionally, refresh content that depends on the selected IP ? 
+                });
+                "#))
+            }
         }
     }
 }
-
 #[allow(non_snake_case)]
 fn Footer() -> Markup {
     html! {

--- a/front/src/template.rs
+++ b/front/src/template.rs
@@ -6,7 +6,7 @@ use front_components::Ref;
 use maud::{html, Markup, PreEscaped, DOCTYPE};
 use strum::{EnumIter, IntoEnumIterator};
 
-use crate::AppState;
+use crate::{AppState, Padded};
 
 #[derive(Debug, Clone, Copy)]
 pub enum ContentMode {
@@ -69,6 +69,11 @@ impl Template {
                 }
             }
         }
+    }
+
+    #[must_use]
+    pub async fn render_padded(self, content: Markup) -> Markup {
+        self.render(Padded(content)).await
     }
 }
 
@@ -134,9 +139,6 @@ async fn Template(
                 meta name="viewport" content="width=device-width, initial-scale=1";
                 script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" {}
                 script src="https://unpkg.com/htmx.org" {}
-                script src="https://unpkg.com/htmx.org/dist/ext/response-targets.js" {}
-                script src="https://unpkg.com/htmx.org/dist/ext/head-support.js" {}
-                script src="https://unpkg.com/htmx.org/dist/ext/ws.js" {}
                 script src="https://cdn.tailwindcss.com" {}
                 script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer {}
                 script {
@@ -240,7 +242,7 @@ async fn Template(
                             headers: { 'Content-Type': 'application/json' },
                             body: JSON.stringify({ ip: selectedIp })
                         });
-                        // Optionally, refresh content that depends on the selected IP ? 
+                        // Optionally, refresh content that depends on the selected IP ?
                     });
                     "#))
                 }

--- a/test.hurl
+++ b/test.hurl
@@ -25,7 +25,7 @@ POST http://localhost:9988/firewall/rules
 Content-Type: application/json
 {
     "name": "Block 8080",
-    "description": "Block access to port 8008",
+    "description": "Block access to port 8080",
     "rule": {
         "action":"drop",
         "matches":{ "port": 8080 },


### PR DESCRIPTION
# Add IP selection and dynamic status update to the firewall

## Description

This pull request introduces the following improvements to the firewall feature:

1. **IP Selection**: Users can now select the IP address they want to apply the firewall rules to. This provides more flexibility and control over the firewall configuration.

2. **Dynamic Status Update**: The firewall status is now updated dynamically, reflecting the current state of the firewall rules. Users can easily see whether the firewall is enabled or disabled.

These changes enhance the user experience and provide more granular control over the firewall functionality.

## Changes

🚀 feat(firewall): Add IP selection and dynamic status update

## Checklist

- [x] Implemented IP selection for the firewall
- [x] Added dynamic status update for the firewall
- [] Tested the new functionality thoroughly
-
## Impact

These changes will improve the user experience and provide more flexibility in managing the firewall. The dynamic status update will also make it easier for users to monitor the firewall's state.

## Reviewers
@lolorein