### PR TITLE
Add POST /firewall/update/:id endpoint

### DIFF
--- a/message/src/firewall.rs
+++ b/message/src/firewall.rs
@@ -13,6 +13,7 @@ pub enum Response {
     Status(Status),
     RuleChange(RuleChange),
     Events(Vec<firewall_common::StoredEventDecoded>),
+    UpdateRule(firewall_common::StoredRuleDecoded),
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -60,4 +61,5 @@ pub enum Request {
     GetRules,
     Status,
     GetEvents(crate::EventQuery),
+    UpdateRule(u32, firewall_common::StoredRuleDecoded),
 }


### PR DESCRIPTION
Related to #30

Add POST /firewall/update/:id endpoint to update firewall rules by ID.

* Add a new request type `UpdateRule` to the `Request` and `Response` enums in `message/src/firewall.rs`.
* Add a new route for `POST /firewall/update/:id` in the `rules` router in `controller/src/firewall/mod.rs`.
* Add a new handler function `update_rule` for the `POST /firewall/update/:id` route in `controller/src/firewall/mod.rs`.
* Implement the logic to update the rule in the `update_rule` function in `controller/src/firewall/mod.rs`.
* Add a new match arm for `Request::UpdateRule` in the `handle_message` function in `firewall/src/main.rs`.
* Implement the logic to update the rule in the `handle_message` function in `firewall/src/main.rs`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AOx0/adam/pull/82?shareId=7d4a50d0-5b55-462b-a49c-cdd5df5b4753).